### PR TITLE
Fix: Broken creative tab translation text below MC Forge 1.19.4

### DIFF
--- a/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/registry/CreativeModeTabHolder.java
+++ b/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/registry/CreativeModeTabHolder.java
@@ -11,7 +11,7 @@ public final class CreativeModeTabHolder {
 	public final ItemGroup creativeModeTab;
 
 	public CreativeModeTabHolder(Identifier identifier, Supplier<ItemStack> iconSupplier) {
-		this.creativeModeTab = new CreativeModeTabImplementation(identifier.data.getPath(), iconSupplier);
+		this.creativeModeTab = new CreativeModeTabImplementation(String.format("%s.%s", identifier.data.getNamespace(), identifier.data.getPath()), iconSupplier);
 	}
 
 	private static final class CreativeModeTabImplementation extends ItemGroup {

--- a/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/registry/Registry.java
+++ b/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/registry/Registry.java
@@ -164,7 +164,7 @@ public final class Registry extends DummyClass {
 			PacketBufferReceiver.receive(packetObject.byteBuf, packetBufferReceiver -> {
 				final Function<PacketBufferReceiver, ? extends PacketHandler> getPacketInstance = packets.get(packetBufferReceiver.readString());
 				if (getPacketInstance != null) {
-					final PacketHandler packetHandler = getPacketInstance.apply(packetBufferReceiver);	
+					final PacketHandler packetHandler = getPacketInstance.apply(packetBufferReceiver);
 					if (context.getDirection().getReceptionSide().isClient()) {
 						packetHandler.runClient();
 					} else {

--- a/forge/1.17.1-mapping/src/main/java/org/mtr/mapping/registry/CreativeModeTabHolder.java
+++ b/forge/1.17.1-mapping/src/main/java/org/mtr/mapping/registry/CreativeModeTabHolder.java
@@ -11,7 +11,7 @@ public final class CreativeModeTabHolder {
 	public final CreativeModeTab creativeModeTab;
 
 	public CreativeModeTabHolder(Identifier identifier, Supplier<ItemStack> iconSupplier) {
-		this.creativeModeTab = new CreativeModeTabImplementation(identifier.data.getPath(), iconSupplier);
+		this.creativeModeTab = new CreativeModeTabImplementation(String.format("%s.%s", identifier.data.getNamespace(), identifier.data.getPath()), iconSupplier);
 	}
 
 	private static final class CreativeModeTabImplementation extends CreativeModeTab {

--- a/forge/1.18.2-mapping/src/main/java/org/mtr/mapping/registry/CreativeModeTabHolder.java
+++ b/forge/1.18.2-mapping/src/main/java/org/mtr/mapping/registry/CreativeModeTabHolder.java
@@ -11,7 +11,7 @@ public final class CreativeModeTabHolder {
 	public final CreativeModeTab creativeModeTab;
 
 	public CreativeModeTabHolder(Identifier identifier, Supplier<ItemStack> iconSupplier) {
-		this.creativeModeTab = new CreativeModeTabImplementation(identifier.data.getPath(), iconSupplier);
+		this.creativeModeTab = new CreativeModeTabImplementation(String.format("%s.%s", identifier.data.getNamespace(), identifier.data.getPath()), iconSupplier);
 	}
 
 	private static final class CreativeModeTabImplementation extends CreativeModeTab {

--- a/forge/1.19.2-mapping/src/main/java/org/mtr/mapping/registry/CreativeModeTabHolder.java
+++ b/forge/1.19.2-mapping/src/main/java/org/mtr/mapping/registry/CreativeModeTabHolder.java
@@ -11,7 +11,7 @@ public final class CreativeModeTabHolder {
 	public final CreativeModeTab creativeModeTab;
 
 	public CreativeModeTabHolder(Identifier identifier, Supplier<ItemStack> iconSupplier) {
-		this.creativeModeTab = new CreativeModeTabImplementation(identifier.data.getPath(), iconSupplier);
+		this.creativeModeTab = new CreativeModeTabImplementation(String.format("%s.%s", identifier.data.getNamespace(), identifier.data.getPath()), iconSupplier);
 	}
 
 	private static final class CreativeModeTabImplementation extends CreativeModeTab {


### PR DESCRIPTION
On Forge 1.16.5 - 1.19.2, the translation for the creative tab is `itemGroup.path` instead of the expected `itemGroup.namespace.path` in Fabric/Forge 1.19.4+, which results in broken translation.
![image](https://github.com/user-attachments/assets/94d7bddc-1aaa-47f4-a329-852442c6b9d3)
This PR fixes that.