### PR TITLE
Add addSelectableChild and Apply matrix in GuiDrawing

### DIFF
--- a/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/mapper/GuiDrawing.java
+++ b/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/mapper/GuiDrawing.java
@@ -5,6 +5,7 @@ import net.minecraft.client.render.BufferBuilder;
 import net.minecraft.client.render.BufferRenderer;
 import net.minecraft.client.render.Tessellator;
 import net.minecraft.client.render.VertexFormats;
+import net.minecraft.util.math.Matrix4f;
 import org.mtr.mapping.annotation.MappedMethod;
 import org.mtr.mapping.holder.Identifier;
 import org.mtr.mapping.holder.MinecraftClient;
@@ -14,13 +15,17 @@ import org.mtr.mapping.tool.DummyClass;
 public final class GuiDrawing extends DummyClass {
 
 	private BufferBuilder bufferBuilder;
+	private Matrix4f matrix;
+	private final GraphicsHolder graphicsHolder;
 
 	@MappedMethod
 	public GuiDrawing(GraphicsHolder graphicsHolder) {
+		this.graphicsHolder = graphicsHolder;
 	}
 
 	@MappedMethod
 	public void beginDrawingRectangle() {
+		matrix = graphicsHolder.matrixStack == null ? null : graphicsHolder.matrixStack.peek().getModel();
 		bufferBuilder = Tessellator.getInstance().getBuffer();
 		RenderSystem.enableBlend();
 		RenderSystem.disableTexture();
@@ -30,12 +35,12 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void drawRectangle(double x1, double y1, double x2, double y2, int color) {
-		if (bufferBuilder != null) {
+		if (matrix != null && bufferBuilder != null) {
 			ColorHelper.unpackColor(color, (a, r, g, b) -> {
-				bufferBuilder.vertex(x1, y1, 0).color(r, g, b, a).next();
-				bufferBuilder.vertex(x1, y2, 0).color(r, g, b, a).next();
-				bufferBuilder.vertex(x2, y2, 0).color(r, g, b, a).next();
-				bufferBuilder.vertex(x2, y1, 0).color(r, g, b, a).next();
+				bufferBuilder.vertex(matrix, (float)x1, (float)y1, 0).color(r, g, b, a).next();
+				bufferBuilder.vertex(matrix, (float)x1, (float)y2, 0).color(r, g, b, a).next();
+				bufferBuilder.vertex(matrix, (float)x2, (float)y2, 0).color(r, g, b, a).next();
+				bufferBuilder.vertex(matrix, (float)x2, (float)y1, 0).color(r, g, b, a).next();
 			});
 		}
 	}
@@ -52,6 +57,7 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void beginDrawingTexture(Identifier identifier) {
+		matrix = graphicsHolder.matrixStack == null ? null : graphicsHolder.matrixStack.peek().getModel();
 		bufferBuilder = Tessellator.getInstance().getBuffer();
 		MinecraftClient.getInstance().getTextureManager().bindTexture(identifier);
 		RenderSystem.color4f(1, 1, 1, 1);
@@ -63,11 +69,11 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void drawTexture(double x1, double y1, double x2, double y2, float u1, float v1, float u2, float v2) {
-		if (bufferBuilder != null) {
-			bufferBuilder.vertex(x1, y1, 0).texture(u1, v1).next();
-			bufferBuilder.vertex(x1, y2, 0).texture(u1, v2).next();
-			bufferBuilder.vertex(x2, y2, 0).texture(u2, v2).next();
-			bufferBuilder.vertex(x2, y1, 0).texture(u2, v1).next();
+		if (matrix != null && bufferBuilder != null) {
+			bufferBuilder.vertex(matrix, (float)x1, (float)y1, 0).texture(u1, v1).next();
+			bufferBuilder.vertex(matrix, (float)x1, (float)y2, 0).texture(u1, v2).next();
+			bufferBuilder.vertex(matrix, (float)x2, (float)y2, 0).texture(u2, v2).next();
+			bufferBuilder.vertex(matrix, (float)x2, (float)y1, 0).texture(u2, v1).next();
 		}
 	}
 

--- a/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/mapper/ScreenExtension.java
+++ b/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/mapper/ScreenExtension.java
@@ -49,6 +49,11 @@ public class ScreenExtension extends ScreenAbstractMapping {
 		addButton(child.data);
 	}
 
+	@MappedMethod
+	public final void addSelectableChild(ClickableWidget child) {
+		addChild(child.data);
+	}
+
 	@Deprecated
 	@Override
 	public final boolean mouseScrolled(double mouseX, double mouseY, double amount) {

--- a/fabric/1.17.1-mapping/src/main/java/org/mtr/mapping/mapper/GuiDrawing.java
+++ b/fabric/1.17.1-mapping/src/main/java/org/mtr/mapping/mapper/GuiDrawing.java
@@ -2,6 +2,7 @@ package org.mtr.mapping.mapper;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.render.*;
+import net.minecraft.util.math.Matrix4f;
 import org.mtr.mapping.annotation.MappedMethod;
 import org.mtr.mapping.holder.Identifier;
 import org.mtr.mapping.tool.ColorHelper;
@@ -10,13 +11,17 @@ import org.mtr.mapping.tool.DummyClass;
 public final class GuiDrawing extends DummyClass {
 
 	private BufferBuilder bufferBuilder;
+	private Matrix4f matrix;
+	private final GraphicsHolder graphicsHolder;
 
 	@MappedMethod
 	public GuiDrawing(GraphicsHolder graphicsHolder) {
+		this.graphicsHolder = graphicsHolder;
 	}
 
 	@MappedMethod
 	public void beginDrawingRectangle() {
+		matrix = graphicsHolder.matrixStack == null ? null : graphicsHolder.matrixStack.peek().getModel();
 		bufferBuilder = Tessellator.getInstance().getBuffer();
 		RenderSystem.enableBlend();
 		RenderSystem.disableTexture();
@@ -27,12 +32,12 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void drawRectangle(double x1, double y1, double x2, double y2, int color) {
-		if (bufferBuilder != null) {
+		if (matrix != null && bufferBuilder != null) {
 			ColorHelper.unpackColor(color, (a, r, g, b) -> {
-				bufferBuilder.vertex(x1, y1, 0).color(r, g, b, a).next();
-				bufferBuilder.vertex(x1, y2, 0).color(r, g, b, a).next();
-				bufferBuilder.vertex(x2, y2, 0).color(r, g, b, a).next();
-				bufferBuilder.vertex(x2, y1, 0).color(r, g, b, a).next();
+				bufferBuilder.vertex(matrix, (float)x1, (float)y1, 0).color(r, g, b, a).next();
+				bufferBuilder.vertex(matrix, (float)x1, (float)y2, 0).color(r, g, b, a).next();
+				bufferBuilder.vertex(matrix, (float)x2, (float)y2, 0).color(r, g, b, a).next();
+				bufferBuilder.vertex(matrix, (float)x2, (float)y1, 0).color(r, g, b, a).next();
 			});
 		}
 	}
@@ -49,6 +54,7 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void beginDrawingTexture(Identifier identifier) {
+		matrix = graphicsHolder.matrixStack == null ? null : graphicsHolder.matrixStack.peek().getModel();
 		bufferBuilder = Tessellator.getInstance().getBuffer();
 		RenderSystem.setShader(GameRenderer::getPositionTexShader);
 		RenderSystem.setShaderTexture(0, identifier.data);
@@ -61,11 +67,11 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void drawTexture(double x1, double y1, double x2, double y2, float u1, float v1, float u2, float v2) {
-		if (bufferBuilder != null) {
-			bufferBuilder.vertex(x1, y1, 0).texture(u1, v1).next();
-			bufferBuilder.vertex(x1, y2, 0).texture(u1, v2).next();
-			bufferBuilder.vertex(x2, y2, 0).texture(u2, v2).next();
-			bufferBuilder.vertex(x2, y1, 0).texture(u2, v1).next();
+		if (matrix != null && bufferBuilder != null) {
+			bufferBuilder.vertex(matrix, (float)x1, (float)y1, 0).texture(u1, v1).next();
+			bufferBuilder.vertex(matrix, (float)x1, (float)y2, 0).texture(u1, v2).next();
+			bufferBuilder.vertex(matrix, (float)x2, (float)y2, 0).texture(u2, v2).next();
+			bufferBuilder.vertex(matrix, (float)x2, (float)y1, 0).texture(u2, v1).next();
 		}
 	}
 

--- a/fabric/1.17.1-mapping/src/main/java/org/mtr/mapping/mapper/ScreenExtension.java
+++ b/fabric/1.17.1-mapping/src/main/java/org/mtr/mapping/mapper/ScreenExtension.java
@@ -49,6 +49,11 @@ public class ScreenExtension extends ScreenAbstractMapping {
 		addDrawableChild(child.data);
 	}
 
+	@MappedMethod
+	public final void addSelectableChild(ClickableWidget child) {
+		addSelectableChild(child.data);
+	}
+
 	@Deprecated
 	@Override
 	public final boolean mouseScrolled(double mouseX, double mouseY, double amount) {

--- a/fabric/1.18.2-mapping/src/main/java/org/mtr/mapping/mapper/GuiDrawing.java
+++ b/fabric/1.18.2-mapping/src/main/java/org/mtr/mapping/mapper/GuiDrawing.java
@@ -2,6 +2,7 @@ package org.mtr.mapping.mapper;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.render.*;
+import net.minecraft.util.math.Matrix4f;
 import org.mtr.mapping.annotation.MappedMethod;
 import org.mtr.mapping.holder.Identifier;
 import org.mtr.mapping.tool.ColorHelper;
@@ -10,13 +11,17 @@ import org.mtr.mapping.tool.DummyClass;
 public final class GuiDrawing extends DummyClass {
 
 	private BufferBuilder bufferBuilder;
+	private Matrix4f matrix;
+	private final GraphicsHolder graphicsHolder;
 
 	@MappedMethod
 	public GuiDrawing(GraphicsHolder graphicsHolder) {
+		this.graphicsHolder = graphicsHolder;
 	}
 
 	@MappedMethod
 	public void beginDrawingRectangle() {
+		matrix = graphicsHolder.matrixStack == null ? null : graphicsHolder.matrixStack.peek().getPositionMatrix();
 		bufferBuilder = Tessellator.getInstance().getBuffer();
 		RenderSystem.enableBlend();
 		RenderSystem.disableTexture();
@@ -27,12 +32,12 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void drawRectangle(double x1, double y1, double x2, double y2, int color) {
-		if (bufferBuilder != null) {
+		if (matrix != null && bufferBuilder != null) {
 			ColorHelper.unpackColor(color, (a, r, g, b) -> {
-				bufferBuilder.vertex(x1, y1, 0).color(r, g, b, a).next();
-				bufferBuilder.vertex(x1, y2, 0).color(r, g, b, a).next();
-				bufferBuilder.vertex(x2, y2, 0).color(r, g, b, a).next();
-				bufferBuilder.vertex(x2, y1, 0).color(r, g, b, a).next();
+				bufferBuilder.vertex(matrix, (float)x1, (float)y1, 0).color(r, g, b, a).next();
+				bufferBuilder.vertex(matrix, (float)x1, (float)y2, 0).color(r, g, b, a).next();
+				bufferBuilder.vertex(matrix, (float)x2, (float)y2, 0).color(r, g, b, a).next();
+				bufferBuilder.vertex(matrix, (float)x2, (float)y1, 0).color(r, g, b, a).next();
 			});
 		}
 	}
@@ -49,6 +54,7 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void beginDrawingTexture(Identifier identifier) {
+		matrix = graphicsHolder.matrixStack == null ? null : graphicsHolder.matrixStack.peek().getPositionMatrix();
 		bufferBuilder = Tessellator.getInstance().getBuffer();
 		RenderSystem.setShader(GameRenderer::getPositionTexShader);
 		RenderSystem.setShaderTexture(0, identifier.data);
@@ -61,11 +67,11 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void drawTexture(double x1, double y1, double x2, double y2, float u1, float v1, float u2, float v2) {
-		if (bufferBuilder != null) {
-			bufferBuilder.vertex(x1, y1, 0).texture(u1, v1).next();
-			bufferBuilder.vertex(x1, y2, 0).texture(u1, v2).next();
-			bufferBuilder.vertex(x2, y2, 0).texture(u2, v2).next();
-			bufferBuilder.vertex(x2, y1, 0).texture(u2, v1).next();
+		if (matrix != null && bufferBuilder != null) {
+			bufferBuilder.vertex(matrix, (float)x1, (float)y1, 0).texture(u1, v1).next();
+			bufferBuilder.vertex(matrix, (float)x1, (float)y2, 0).texture(u1, v2).next();
+			bufferBuilder.vertex(matrix, (float)x2, (float)y2, 0).texture(u2, v2).next();
+			bufferBuilder.vertex(matrix, (float)x2, (float)y1, 0).texture(u2, v1).next();
 		}
 	}
 

--- a/fabric/1.18.2-mapping/src/main/java/org/mtr/mapping/mapper/ScreenExtension.java
+++ b/fabric/1.18.2-mapping/src/main/java/org/mtr/mapping/mapper/ScreenExtension.java
@@ -49,6 +49,11 @@ public class ScreenExtension extends ScreenAbstractMapping {
 		addDrawableChild(child.data);
 	}
 
+	@MappedMethod
+	public final void addSelectableChild(ClickableWidget child) {
+		addSelectableChild(child.data);
+	}
+
 	@Deprecated
 	@Override
 	public final boolean mouseScrolled(double mouseX, double mouseY, double amount) {

--- a/fabric/1.19.2-mapping/src/main/java/org/mtr/mapping/mapper/GuiDrawing.java
+++ b/fabric/1.19.2-mapping/src/main/java/org/mtr/mapping/mapper/GuiDrawing.java
@@ -2,6 +2,7 @@ package org.mtr.mapping.mapper;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.render.*;
+import net.minecraft.util.math.Matrix4f;
 import org.mtr.mapping.annotation.MappedMethod;
 import org.mtr.mapping.holder.Identifier;
 import org.mtr.mapping.tool.ColorHelper;
@@ -10,13 +11,17 @@ import org.mtr.mapping.tool.DummyClass;
 public final class GuiDrawing extends DummyClass {
 
 	private BufferBuilder bufferBuilder;
+	private Matrix4f matrix;
+	private final GraphicsHolder graphicsHolder;
 
 	@MappedMethod
 	public GuiDrawing(GraphicsHolder graphicsHolder) {
+		this.graphicsHolder = graphicsHolder;
 	}
 
 	@MappedMethod
 	public void beginDrawingRectangle() {
+		matrix = graphicsHolder.matrixStack == null ? null : graphicsHolder.matrixStack.peek().getPositionMatrix();
 		bufferBuilder = Tessellator.getInstance().getBuffer();
 		RenderSystem.enableBlend();
 		RenderSystem.setShader(GameRenderer::getPositionColorShader);
@@ -25,12 +30,12 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void drawRectangle(double x1, double y1, double x2, double y2, int color) {
-		if (bufferBuilder != null) {
+		if (matrix != null && bufferBuilder != null) {
 			ColorHelper.unpackColor(color, (a, r, g, b) -> {
-				bufferBuilder.vertex(x1, y1, 0).color(r, g, b, a).next();
-				bufferBuilder.vertex(x1, y2, 0).color(r, g, b, a).next();
-				bufferBuilder.vertex(x2, y2, 0).color(r, g, b, a).next();
-				bufferBuilder.vertex(x2, y1, 0).color(r, g, b, a).next();
+				bufferBuilder.vertex(matrix, (float)x1, (float)y1, 0).color(r, g, b, a).next();
+				bufferBuilder.vertex(matrix, (float)x1, (float)y2, 0).color(r, g, b, a).next();
+				bufferBuilder.vertex(matrix, (float)x2, (float)y2, 0).color(r, g, b, a).next();
+				bufferBuilder.vertex(matrix, (float)x2, (float)y1, 0).color(r, g, b, a).next();
 			});
 		}
 	}
@@ -43,6 +48,7 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void beginDrawingTexture(Identifier identifier) {
+		matrix = graphicsHolder.matrixStack == null ? null : graphicsHolder.matrixStack.peek().getPositionMatrix();
 		bufferBuilder = Tessellator.getInstance().getBuffer();
 		RenderSystem.setShaderTexture(0, identifier.data);
 		RenderSystem.enableDepthTest();
@@ -51,12 +57,12 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void drawTexture(double x1, double y1, double x2, double y2, float u1, float v1, float u2, float v2) {
-		if (bufferBuilder != null) {
+		if (matrix != null && bufferBuilder != null) {
 			bufferBuilder.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_TEXTURE);
-			bufferBuilder.vertex(x1, y1, 0).texture(u1, v1).next();
-			bufferBuilder.vertex(x1, y2, 0).texture(u1, v2).next();
-			bufferBuilder.vertex(x2, y2, 0).texture(u2, v2).next();
-			bufferBuilder.vertex(x2, y1, 0).texture(u2, v1).next();
+			bufferBuilder.vertex(matrix, (float)x1, (float)y1, 0).texture(u1, v1).next();
+			bufferBuilder.vertex(matrix, (float)x1, (float)y2, 0).texture(u1, v2).next();
+			bufferBuilder.vertex(matrix, (float)x2, (float)y2, 0).texture(u2, v2).next();
+			bufferBuilder.vertex(matrix, (float)x2, (float)y1, 0).texture(u2, v1).next();
 			BufferRenderer.drawWithShader(bufferBuilder.end());
 		}
 	}

--- a/fabric/1.19.2-mapping/src/main/java/org/mtr/mapping/mapper/ScreenExtension.java
+++ b/fabric/1.19.2-mapping/src/main/java/org/mtr/mapping/mapper/ScreenExtension.java
@@ -49,6 +49,11 @@ public class ScreenExtension extends ScreenAbstractMapping {
 		addDrawableChild(child.data);
 	}
 
+	@MappedMethod
+	public final void addSelectableChild(ClickableWidget child) {
+		addSelectableChild(child.data);
+	}
+
 	@Deprecated
 	@Override
 	public final boolean mouseScrolled(double mouseX, double mouseY, double amount) {

--- a/fabric/1.19.4-mapping/src/main/java/org/mtr/mapping/mapper/GuiDrawing.java
+++ b/fabric/1.19.4-mapping/src/main/java/org/mtr/mapping/mapper/GuiDrawing.java
@@ -2,6 +2,7 @@ package org.mtr.mapping.mapper;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.render.*;
+import org.joml.Matrix4f;
 import org.mtr.mapping.annotation.MappedMethod;
 import org.mtr.mapping.holder.Identifier;
 import org.mtr.mapping.tool.ColorHelper;
@@ -10,13 +11,17 @@ import org.mtr.mapping.tool.DummyClass;
 public final class GuiDrawing extends DummyClass {
 
 	private BufferBuilder bufferBuilder;
+	private Matrix4f matrix;
+	private final GraphicsHolder graphicsHolder;
 
 	@MappedMethod
 	public GuiDrawing(GraphicsHolder graphicsHolder) {
+		this.graphicsHolder = graphicsHolder;
 	}
 
 	@MappedMethod
 	public void beginDrawingRectangle() {
+		matrix = graphicsHolder.matrixStack == null ? null : graphicsHolder.matrixStack.peek().getPositionMatrix();
 		bufferBuilder = Tessellator.getInstance().getBuffer();
 		RenderSystem.enableBlend();
 		RenderSystem.setShader(GameRenderer::getPositionColorProgram);
@@ -25,12 +30,12 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void drawRectangle(double x1, double y1, double x2, double y2, int color) {
-		if (bufferBuilder != null) {
+		if (matrix != null && bufferBuilder != null) {
 			ColorHelper.unpackColor(color, (a, r, g, b) -> {
-				bufferBuilder.vertex(x1, y1, 0).color(r, g, b, a).next();
-				bufferBuilder.vertex(x1, y2, 0).color(r, g, b, a).next();
-				bufferBuilder.vertex(x2, y2, 0).color(r, g, b, a).next();
-				bufferBuilder.vertex(x2, y1, 0).color(r, g, b, a).next();
+				bufferBuilder.vertex(matrix, (float)x1, (float)y1, 0).color(r, g, b, a).next();
+				bufferBuilder.vertex(matrix, (float)x1, (float)y2, 0).color(r, g, b, a).next();
+				bufferBuilder.vertex(matrix, (float)x2, (float)y2, 0).color(r, g, b, a).next();
+				bufferBuilder.vertex(matrix, (float)x2, (float)y1, 0).color(r, g, b, a).next();
 			});
 		}
 	}
@@ -43,6 +48,7 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void beginDrawingTexture(Identifier identifier) {
+		matrix = graphicsHolder.matrixStack == null ? null : graphicsHolder.matrixStack.peek().getPositionMatrix();
 		bufferBuilder = Tessellator.getInstance().getBuffer();
 		RenderSystem.setShaderTexture(0, identifier.data);
 		RenderSystem.enableDepthTest();
@@ -51,12 +57,12 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void drawTexture(double x1, double y1, double x2, double y2, float u1, float v1, float u2, float v2) {
-		if (bufferBuilder != null) {
+		if (matrix != null && bufferBuilder != null) {
 			bufferBuilder.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_TEXTURE);
-			bufferBuilder.vertex(x1, y1, 0).texture(u1, v1).next();
-			bufferBuilder.vertex(x1, y2, 0).texture(u1, v2).next();
-			bufferBuilder.vertex(x2, y2, 0).texture(u2, v2).next();
-			bufferBuilder.vertex(x2, y1, 0).texture(u2, v1).next();
+			bufferBuilder.vertex(matrix, (float)x1, (float)y1, 0).texture(u1, v1).next();
+			bufferBuilder.vertex(matrix, (float)x1, (float)y2, 0).texture(u1, v2).next();
+			bufferBuilder.vertex(matrix, (float)x2, (float)y2, 0).texture(u2, v2).next();
+			bufferBuilder.vertex(matrix, (float)x2, (float)y1, 0).texture(u2, v1).next();
 			BufferRenderer.drawWithGlobalProgram(bufferBuilder.end());
 		}
 	}

--- a/fabric/1.19.4-mapping/src/main/java/org/mtr/mapping/mapper/ScreenExtension.java
+++ b/fabric/1.19.4-mapping/src/main/java/org/mtr/mapping/mapper/ScreenExtension.java
@@ -49,6 +49,11 @@ public class ScreenExtension extends ScreenAbstractMapping {
 		addDrawableChild(child.data);
 	}
 
+	@MappedMethod
+	public final void addSelectableChild(ClickableWidget child) {
+		addSelectableChild(child.data);
+	}
+
 	@Deprecated
 	@Override
 	public final boolean mouseScrolled(double mouseX, double mouseY, double amount) {

--- a/fabric/1.20.1-mapping/src/main/java/org/mtr/mapping/mapper/GuiDrawing.java
+++ b/fabric/1.20.1-mapping/src/main/java/org/mtr/mapping/mapper/GuiDrawing.java
@@ -3,6 +3,7 @@ package org.mtr.mapping.mapper;
 import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.render.*;
+import org.joml.Matrix4f;
 import org.mtr.mapping.annotation.MappedMethod;
 import org.mtr.mapping.holder.Identifier;
 import org.mtr.mapping.tool.ColorHelper;
@@ -13,6 +14,7 @@ public final class GuiDrawing extends DummyClass {
 	private VertexConsumer vertexConsumer;
 	private DrawContext drawContext;
 	private BufferBuilder bufferBuilder;
+	private Matrix4f matrix;
 	private final GraphicsHolder graphicsHolder;
 
 	@MappedMethod
@@ -22,18 +24,19 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void beginDrawingRectangle() {
+		matrix = graphicsHolder.matrixStack == null ? null : graphicsHolder.matrixStack.peek().getPositionMatrix();
 		vertexConsumer = graphicsHolder.vertexConsumerProvider == null ? null : graphicsHolder.vertexConsumerProvider.getBuffer(net.minecraft.client.render.RenderLayer.getGui());
 		drawContext = graphicsHolder.drawContext;
 	}
 
 	@MappedMethod
 	public void drawRectangle(double x1, double y1, double x2, double y2, int color) {
-		if (vertexConsumer != null && drawContext != null) {
+		if (matrix != null && vertexConsumer != null && drawContext != null) {
 			ColorHelper.unpackColor(color, (a, r, g, b) -> {
-				vertexConsumer.vertex(x1, y1, 0).color(r, g, b, a).next();
-				vertexConsumer.vertex(x1, y2, 0).color(r, g, b, a).next();
-				vertexConsumer.vertex(x2, y2, 0).color(r, g, b, a).next();
-				vertexConsumer.vertex(x2, y1, 0).color(r, g, b, a).next();
+				vertexConsumer.vertex(matrix, (float)x1, (float)y1, 0).color(r, g, b, a).next();
+				vertexConsumer.vertex(matrix, (float)x1, (float)y2, 0).color(r, g, b, a).next();
+				vertexConsumer.vertex(matrix, (float)x2, (float)y2, 0).color(r, g, b, a).next();
+				vertexConsumer.vertex(matrix, (float)x2, (float)y1, 0).color(r, g, b, a).next();
 			});
 		}
 	}
@@ -47,6 +50,7 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void beginDrawingTexture(Identifier identifier) {
+		matrix = graphicsHolder.matrixStack == null ? null : graphicsHolder.matrixStack.peek().getPositionMatrix();
 		bufferBuilder = Tessellator.getInstance().getBuffer();
 		RenderSystem.setShaderTexture(0, identifier.data);
 		RenderSystem.enableDepthTest();
@@ -56,11 +60,11 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void drawTexture(double x1, double y1, double x2, double y2, float u1, float v1, float u2, float v2) {
-		if (bufferBuilder != null) {
-			bufferBuilder.vertex(x1, y1, 0).texture(u1, v1).next();
-			bufferBuilder.vertex(x1, y2, 0).texture(u1, v2).next();
-			bufferBuilder.vertex(x2, y2, 0).texture(u2, v2).next();
-			bufferBuilder.vertex(x2, y1, 0).texture(u2, v1).next();
+		if (matrix != null && bufferBuilder != null) {
+			bufferBuilder.vertex(matrix, (float)x1, (float)y1, 0).texture(u1, v1).next();
+			bufferBuilder.vertex(matrix, (float)x1, (float)y2, 0).texture(u1, v2).next();
+			bufferBuilder.vertex(matrix, (float)x2, (float)y2, 0).texture(u2, v2).next();
+			bufferBuilder.vertex(matrix, (float)x2, (float)y1, 0).texture(u2, v1).next();
 		}
 	}
 

--- a/fabric/1.20.1-mapping/src/main/java/org/mtr/mapping/mapper/ScreenExtension.java
+++ b/fabric/1.20.1-mapping/src/main/java/org/mtr/mapping/mapper/ScreenExtension.java
@@ -53,6 +53,11 @@ public class ScreenExtension extends ScreenAbstractMapping {
 		addDrawableChild(child.data);
 	}
 
+	@MappedMethod
+	public final void addSelectableChild(ClickableWidget child) {
+		addSelectableChild(child.data);
+	}
+
 	@Deprecated
 	public final boolean mouseScrolled(double mouseX, double mouseY, double horizontalAmount, double verticalAmount) {
 		return mouseScrolled2(mouseX, mouseY, verticalAmount);

--- a/fabric/1.20.4-mapping/src/main/java/org/mtr/mapping/mapper/GuiDrawing.java
+++ b/fabric/1.20.4-mapping/src/main/java/org/mtr/mapping/mapper/GuiDrawing.java
@@ -3,6 +3,7 @@ package org.mtr.mapping.mapper;
 import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.render.*;
+import org.joml.Matrix4f;
 import org.mtr.mapping.annotation.MappedMethod;
 import org.mtr.mapping.holder.Identifier;
 import org.mtr.mapping.tool.ColorHelper;
@@ -13,6 +14,7 @@ public final class GuiDrawing extends DummyClass {
 	private VertexConsumer vertexConsumer;
 	private DrawContext drawContext;
 	private BufferBuilder bufferBuilder;
+	private Matrix4f matrix;
 	private final GraphicsHolder graphicsHolder;
 
 	@MappedMethod
@@ -22,31 +24,33 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void beginDrawingRectangle() {
+		matrix = graphicsHolder.matrixStack == null ? null : graphicsHolder.matrixStack.peek().getPositionMatrix();
 		vertexConsumer = graphicsHolder.vertexConsumerProvider == null ? null : graphicsHolder.vertexConsumerProvider.getBuffer(net.minecraft.client.render.RenderLayer.getGui());
 		drawContext = graphicsHolder.drawContext;
 	}
 
 	@MappedMethod
 	public void drawRectangle(double x1, double y1, double x2, double y2, int color) {
-		if (vertexConsumer != null && drawContext != null) {
+		if (matrix != null && vertexConsumer != null && drawContext != null) {
 			ColorHelper.unpackColor(color, (a, r, g, b) -> {
-				vertexConsumer.vertex(x1, y1, 0).color(r, g, b, a).next();
-				vertexConsumer.vertex(x1, y2, 0).color(r, g, b, a).next();
-				vertexConsumer.vertex(x2, y2, 0).color(r, g, b, a).next();
-				vertexConsumer.vertex(x2, y1, 0).color(r, g, b, a).next();
+				vertexConsumer.vertex(matrix, (float)x1, (float)y1, 0).color(r, g, b, a).next();
+				vertexConsumer.vertex(matrix, (float)x1, (float)y2, 0).color(r, g, b, a).next();
+				vertexConsumer.vertex(matrix, (float)x2, (float)y2, 0).color(r, g, b, a).next();
+				vertexConsumer.vertex(matrix, (float)x2, (float)y1, 0).color(r, g, b, a).next();
 			});
 		}
 	}
 
 	@MappedMethod
 	public void finishDrawingRectangle() {
-		if (vertexConsumer != null && drawContext != null) {
+		if (matrix != null && vertexConsumer != null && drawContext != null) {
 			drawContext.draw();
 		}
 	}
 
 	@MappedMethod
 	public void beginDrawingTexture(Identifier identifier) {
+		matrix = graphicsHolder.matrixStack == null ? null : graphicsHolder.matrixStack.peek().getPositionMatrix();
 		bufferBuilder = Tessellator.getInstance().getBuffer();
 		RenderSystem.setShaderTexture(0, identifier.data);
 		RenderSystem.enableDepthTest();
@@ -56,11 +60,11 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void drawTexture(double x1, double y1, double x2, double y2, float u1, float v1, float u2, float v2) {
-		if (bufferBuilder != null) {
-			bufferBuilder.vertex(x1, y1, 0).texture(u1, v1).next();
-			bufferBuilder.vertex(x1, y2, 0).texture(u1, v2).next();
-			bufferBuilder.vertex(x2, y2, 0).texture(u2, v2).next();
-			bufferBuilder.vertex(x2, y1, 0).texture(u2, v1).next();
+		if (matrix != null && bufferBuilder != null) {
+			bufferBuilder.vertex(matrix, (float)x1, (float)y1, 0).texture(u1, v1).next();
+			bufferBuilder.vertex(matrix, (float)x1, (float)y2, 0).texture(u1, v2).next();
+			bufferBuilder.vertex(matrix, (float)x2, (float)y2, 0).texture(u2, v2).next();
+			bufferBuilder.vertex(matrix, (float)x2, (float)y1, 0).texture(u2, v1).next();
 		}
 	}
 

--- a/fabric/1.20.4-mapping/src/main/java/org/mtr/mapping/mapper/ScreenExtension.java
+++ b/fabric/1.20.4-mapping/src/main/java/org/mtr/mapping/mapper/ScreenExtension.java
@@ -54,6 +54,11 @@ public class ScreenExtension extends ScreenAbstractMapping {
 		addDrawableChild(child.data);
 	}
 
+	@MappedMethod
+	public final void addSelectableChild(ClickableWidget child) {
+		addSelectableChild(child.data);
+	}
+
 	@Deprecated
 	@Override
 	public final boolean mouseScrolled(double mouseX, double mouseY, double horizontalAmount, double verticalAmount) {

--- a/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/mapper/GuiDrawing.java
+++ b/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/mapper/GuiDrawing.java
@@ -5,6 +5,7 @@ import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.WorldVertexBufferUploader;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
+import net.minecraft.util.math.vector.Matrix4f;
 import org.mtr.mapping.annotation.MappedMethod;
 import org.mtr.mapping.holder.Identifier;
 import org.mtr.mapping.holder.MinecraftClient;
@@ -14,13 +15,17 @@ import org.mtr.mapping.tool.DummyClass;
 public final class GuiDrawing extends DummyClass {
 
 	private BufferBuilder bufferBuilder;
+	private Matrix4f matrix;
+	private final GraphicsHolder graphicsHolder;
 
 	@MappedMethod
 	public GuiDrawing(GraphicsHolder graphicsHolder) {
+		this.graphicsHolder = graphicsHolder;
 	}
 
 	@MappedMethod
 	public void beginDrawingRectangle() {
+		matrix = graphicsHolder.matrixStack == null ? null : graphicsHolder.matrixStack.last().pose();
 		bufferBuilder = Tessellator.getInstance().getBuilder();
 		RenderSystem.enableBlend();
 		RenderSystem.disableTexture();
@@ -30,12 +35,12 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void drawRectangle(double x1, double y1, double x2, double y2, int color) {
-		if (bufferBuilder != null) {
+		if (matrix != null && bufferBuilder != null) {
 			ColorHelper.unpackColor(color, (a, r, g, b) -> {
-				bufferBuilder.vertex(x1, y1, 0).color(r, g, b, a).endVertex();
-				bufferBuilder.vertex(x1, y2, 0).color(r, g, b, a).endVertex();
-				bufferBuilder.vertex(x2, y2, 0).color(r, g, b, a).endVertex();
-				bufferBuilder.vertex(x2, y1, 0).color(r, g, b, a).endVertex();
+				bufferBuilder.vertex(matrix, (float)x1, (float)y1, 0).color(r, g, b, a).endVertex();
+				bufferBuilder.vertex(matrix, (float)x1, (float)y2, 0).color(r, g, b, a).endVertex();
+				bufferBuilder.vertex(matrix, (float)x2, (float)y2, 0).color(r, g, b, a).endVertex();
+				bufferBuilder.vertex(matrix, (float)x2, (float)y1, 0).color(r, g, b, a).endVertex();
 			});
 		}
 	}
@@ -52,6 +57,7 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void beginDrawingTexture(Identifier identifier) {
+		matrix = graphicsHolder.matrixStack == null ? null : graphicsHolder.matrixStack.last().pose();
 		bufferBuilder = Tessellator.getInstance().getBuilder();
 		MinecraftClient.getInstance().getTextureManager().bindTexture(identifier);
 		RenderSystem.color4f(1, 1, 1, 1);
@@ -63,11 +69,11 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void drawTexture(double x1, double y1, double x2, double y2, float u1, float v1, float u2, float v2) {
-		if (bufferBuilder != null) {
-			bufferBuilder.vertex(x1, y1, 0).uv(u1, v1).endVertex();
-			bufferBuilder.vertex(x1, y2, 0).uv(u1, v2).endVertex();
-			bufferBuilder.vertex(x2, y2, 0).uv(u2, v2).endVertex();
-			bufferBuilder.vertex(x2, y1, 0).uv(u2, v1).endVertex();
+		if (matrix != null && bufferBuilder != null) {
+			bufferBuilder.vertex(matrix, (float)x1, (float)y1, 0).uv(u1, v1).endVertex();
+			bufferBuilder.vertex(matrix, (float)x1, (float)y2, 0).uv(u1, v2).endVertex();
+			bufferBuilder.vertex(matrix, (float)x2, (float)y2, 0).uv(u2, v2).endVertex();
+			bufferBuilder.vertex(matrix, (float)x2, (float)y1, 0).uv(u2, v1).endVertex();
 		}
 	}
 

--- a/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/mapper/ScreenExtension.java
+++ b/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/mapper/ScreenExtension.java
@@ -49,6 +49,11 @@ public class ScreenExtension extends ScreenAbstractMapping {
 		addButton(child.data);
 	}
 
+	@MappedMethod
+	public final void addSelectableChild(ClickableWidget child) {
+		addWidget(child.data);
+	}
+
 	@Deprecated
 	@Override
 	public final boolean mouseScrolled(double mouseX, double mouseY, double amount) {

--- a/forge/1.17.1-mapping/src/main/java/org/mtr/mapping/mapper/GuiDrawing.java
+++ b/forge/1.17.1-mapping/src/main/java/org/mtr/mapping/mapper/GuiDrawing.java
@@ -2,6 +2,7 @@ package org.mtr.mapping.mapper;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.*;
+import com.mojang.math.Matrix4f;
 import net.minecraft.client.renderer.GameRenderer;
 import org.mtr.mapping.annotation.MappedMethod;
 import org.mtr.mapping.holder.Identifier;
@@ -11,13 +12,17 @@ import org.mtr.mapping.tool.DummyClass;
 public final class GuiDrawing extends DummyClass {
 
 	private BufferBuilder bufferBuilder;
+	private Matrix4f matrix;
+	private final GraphicsHolder graphicsHolder;
 
 	@MappedMethod
 	public GuiDrawing(GraphicsHolder graphicsHolder) {
+		this.graphicsHolder = graphicsHolder;
 	}
 
 	@MappedMethod
 	public void beginDrawingRectangle() {
+		matrix = graphicsHolder.matrixStack == null ? null : graphicsHolder.matrixStack.last().pose();
 		bufferBuilder = Tesselator.getInstance().getBuilder();
 		RenderSystem.enableBlend();
 		RenderSystem.disableTexture();
@@ -28,12 +33,12 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void drawRectangle(double x1, double y1, double x2, double y2, int color) {
-		if (bufferBuilder != null) {
+		if (matrix != null && bufferBuilder != null) {
 			ColorHelper.unpackColor(color, (a, r, g, b) -> {
-				bufferBuilder.vertex(x1, y1, 0).color(r, g, b, a).endVertex();
-				bufferBuilder.vertex(x1, y2, 0).color(r, g, b, a).endVertex();
-				bufferBuilder.vertex(x2, y2, 0).color(r, g, b, a).endVertex();
-				bufferBuilder.vertex(x2, y1, 0).color(r, g, b, a).endVertex();
+				bufferBuilder.vertex(matrix, (float)x1, (float)y1, 0).color(r, g, b, a).endVertex();
+				bufferBuilder.vertex(matrix, (float)x1, (float)y2, 0).color(r, g, b, a).endVertex();
+				bufferBuilder.vertex(matrix, (float)x2, (float)y2, 0).color(r, g, b, a).endVertex();
+				bufferBuilder.vertex(matrix, (float)x2, (float)y1, 0).color(r, g, b, a).endVertex();
 			});
 		}
 	}
@@ -50,6 +55,7 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void beginDrawingTexture(Identifier identifier) {
+		matrix = graphicsHolder.matrixStack == null ? null : graphicsHolder.matrixStack.last().pose();
 		bufferBuilder = Tesselator.getInstance().getBuilder();
 		RenderSystem.setShader(GameRenderer::getPositionTexShader);
 		RenderSystem.setShaderTexture(0, identifier.data);
@@ -62,11 +68,11 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void drawTexture(double x1, double y1, double x2, double y2, float u1, float v1, float u2, float v2) {
-		if (bufferBuilder != null) {
-			bufferBuilder.vertex(x1, y1, 0).uv(u1, v1).endVertex();
-			bufferBuilder.vertex(x1, y2, 0).uv(u1, v2).endVertex();
-			bufferBuilder.vertex(x2, y2, 0).uv(u2, v2).endVertex();
-			bufferBuilder.vertex(x2, y1, 0).uv(u2, v1).endVertex();
+		if (matrix != null && bufferBuilder != null) {
+			bufferBuilder.vertex(matrix, (float)x1, (float)y1, 0).uv(u1, v1).endVertex();
+			bufferBuilder.vertex(matrix, (float)x1, (float)y2, 0).uv(u1, v2).endVertex();
+			bufferBuilder.vertex(matrix, (float)x2, (float)y2, 0).uv(u2, v2).endVertex();
+			bufferBuilder.vertex(matrix, (float)x2, (float)y1, 0).uv(u2, v1).endVertex();
 		}
 	}
 

--- a/forge/1.17.1-mapping/src/main/java/org/mtr/mapping/mapper/ScreenExtension.java
+++ b/forge/1.17.1-mapping/src/main/java/org/mtr/mapping/mapper/ScreenExtension.java
@@ -49,6 +49,11 @@ public class ScreenExtension extends ScreenAbstractMapping {
 		addRenderableWidget(child.data);
 	}
 
+	@MappedMethod
+	public final void addSelectableChild(ClickableWidget child) {
+		addWidget(child.data);
+	}
+
 	@Deprecated
 	@Override
 	public final boolean mouseScrolled(double mouseX, double mouseY, double amount) {

--- a/forge/1.18.2-mapping/src/main/java/org/mtr/mapping/mapper/GuiDrawing.java
+++ b/forge/1.18.2-mapping/src/main/java/org/mtr/mapping/mapper/GuiDrawing.java
@@ -2,6 +2,7 @@ package org.mtr.mapping.mapper;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.*;
+import com.mojang.math.Matrix4f;
 import net.minecraft.client.renderer.GameRenderer;
 import org.mtr.mapping.annotation.MappedMethod;
 import org.mtr.mapping.holder.Identifier;
@@ -11,13 +12,17 @@ import org.mtr.mapping.tool.DummyClass;
 public final class GuiDrawing extends DummyClass {
 
 	private BufferBuilder bufferBuilder;
+	private Matrix4f matrix;
+	private final GraphicsHolder graphicsHolder;
 
 	@MappedMethod
 	public GuiDrawing(GraphicsHolder graphicsHolder) {
+		this.graphicsHolder = graphicsHolder;
 	}
 
 	@MappedMethod
 	public void beginDrawingRectangle() {
+		matrix = graphicsHolder.matrixStack == null ? null : graphicsHolder.matrixStack.last().pose();
 		bufferBuilder = Tesselator.getInstance().getBuilder();
 		RenderSystem.enableBlend();
 		RenderSystem.disableTexture();
@@ -28,12 +33,12 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void drawRectangle(double x1, double y1, double x2, double y2, int color) {
-		if (bufferBuilder != null) {
+		if (matrix != null && bufferBuilder != null) {
 			ColorHelper.unpackColor(color, (a, r, g, b) -> {
-				bufferBuilder.vertex(x1, y1, 0).color(r, g, b, a).endVertex();
-				bufferBuilder.vertex(x1, y2, 0).color(r, g, b, a).endVertex();
-				bufferBuilder.vertex(x2, y2, 0).color(r, g, b, a).endVertex();
-				bufferBuilder.vertex(x2, y1, 0).color(r, g, b, a).endVertex();
+				bufferBuilder.vertex(matrix, (float)x1, (float)y1, 0).color(r, g, b, a).endVertex();
+				bufferBuilder.vertex(matrix, (float)x1, (float)y2, 0).color(r, g, b, a).endVertex();
+				bufferBuilder.vertex(matrix, (float)x2, (float)y2, 0).color(r, g, b, a).endVertex();
+				bufferBuilder.vertex(matrix, (float)x2, (float)y1, 0).color(r, g, b, a).endVertex();
 			});
 		}
 	}
@@ -50,6 +55,7 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void beginDrawingTexture(Identifier identifier) {
+		matrix = graphicsHolder.matrixStack == null ? null : graphicsHolder.matrixStack.last().pose();
 		bufferBuilder = Tesselator.getInstance().getBuilder();
 		RenderSystem.setShader(GameRenderer::getPositionTexShader);
 		RenderSystem.setShaderTexture(0, identifier.data);
@@ -62,11 +68,11 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void drawTexture(double x1, double y1, double x2, double y2, float u1, float v1, float u2, float v2) {
-		if (bufferBuilder != null) {
-			bufferBuilder.vertex(x1, y1, 0).uv(u1, v1).endVertex();
-			bufferBuilder.vertex(x1, y2, 0).uv(u1, v2).endVertex();
-			bufferBuilder.vertex(x2, y2, 0).uv(u2, v2).endVertex();
-			bufferBuilder.vertex(x2, y1, 0).uv(u2, v1).endVertex();
+		if (matrix != null && bufferBuilder != null) {
+			bufferBuilder.vertex(matrix, (float)x1, (float)y1, 0).uv(u1, v1).endVertex();
+			bufferBuilder.vertex(matrix, (float)x1, (float)y2, 0).uv(u1, v2).endVertex();
+			bufferBuilder.vertex(matrix, (float)x2, (float)y2, 0).uv(u2, v2).endVertex();
+			bufferBuilder.vertex(matrix, (float)x2, (float)y1, 0).uv(u2, v1).endVertex();
 		}
 	}
 

--- a/forge/1.18.2-mapping/src/main/java/org/mtr/mapping/mapper/ScreenExtension.java
+++ b/forge/1.18.2-mapping/src/main/java/org/mtr/mapping/mapper/ScreenExtension.java
@@ -49,6 +49,11 @@ public class ScreenExtension extends ScreenAbstractMapping {
 		addRenderableWidget(child.data);
 	}
 
+	@MappedMethod
+	public final void addSelectableChild(ClickableWidget child) {
+		addWidget(child.data);
+	}
+
 	@Deprecated
 	@Override
 	public final boolean mouseScrolled(double mouseX, double mouseY, double amount) {

--- a/forge/1.19.2-mapping/src/main/java/org/mtr/mapping/mapper/GuiDrawing.java
+++ b/forge/1.19.2-mapping/src/main/java/org/mtr/mapping/mapper/GuiDrawing.java
@@ -2,6 +2,7 @@ package org.mtr.mapping.mapper;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.*;
+import com.mojang.math.Matrix4f;
 import net.minecraft.client.renderer.GameRenderer;
 import org.mtr.mapping.annotation.MappedMethod;
 import org.mtr.mapping.holder.Identifier;
@@ -11,13 +12,17 @@ import org.mtr.mapping.tool.DummyClass;
 public final class GuiDrawing extends DummyClass {
 
 	private BufferBuilder bufferBuilder;
+	private Matrix4f matrix;
+	private final GraphicsHolder graphicsHolder;
 
 	@MappedMethod
 	public GuiDrawing(GraphicsHolder graphicsHolder) {
+		this.graphicsHolder = graphicsHolder;
 	}
 
 	@MappedMethod
 	public void beginDrawingRectangle() {
+		matrix = graphicsHolder.matrixStack == null ? null : graphicsHolder.matrixStack.last().pose();
 		bufferBuilder = Tesselator.getInstance().getBuilder();
 		RenderSystem.enableBlend();
 		RenderSystem.setShader(GameRenderer::getPositionColorShader);
@@ -26,12 +31,12 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void drawRectangle(double x1, double y1, double x2, double y2, int color) {
-		if (bufferBuilder != null) {
+		if (matrix != null && bufferBuilder != null) {
 			ColorHelper.unpackColor(color, (a, r, g, b) -> {
-				bufferBuilder.vertex(x1, y1, 0).color(r, g, b, a).endVertex();
-				bufferBuilder.vertex(x1, y2, 0).color(r, g, b, a).endVertex();
-				bufferBuilder.vertex(x2, y2, 0).color(r, g, b, a).endVertex();
-				bufferBuilder.vertex(x2, y1, 0).color(r, g, b, a).endVertex();
+				bufferBuilder.vertex(matrix, (float)x1, (float)y1, 0).color(r, g, b, a).endVertex();
+				bufferBuilder.vertex(matrix, (float)x1, (float)y2, 0).color(r, g, b, a).endVertex();
+				bufferBuilder.vertex(matrix, (float)x2, (float)y2, 0).color(r, g, b, a).endVertex();
+				bufferBuilder.vertex(matrix, (float)x2, (float)y1, 0).color(r, g, b, a).endVertex();
 			});
 		}
 	}
@@ -44,6 +49,7 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void beginDrawingTexture(Identifier identifier) {
+		matrix = graphicsHolder.matrixStack == null ? null : graphicsHolder.matrixStack.last().pose();
 		bufferBuilder = Tesselator.getInstance().getBuilder();
 		RenderSystem.setShaderTexture(0, identifier.data);
 		RenderSystem.enableDepthTest();
@@ -52,12 +58,12 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void drawTexture(double x1, double y1, double x2, double y2, float u1, float v1, float u2, float v2) {
-		if (bufferBuilder != null) {
+		if (matrix != null && bufferBuilder != null) {
 			bufferBuilder.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_TEX);
-			bufferBuilder.vertex(x1, y1, 0).uv(u1, v1).endVertex();
-			bufferBuilder.vertex(x1, y2, 0).uv(u1, v2).endVertex();
-			bufferBuilder.vertex(x2, y2, 0).uv(u2, v2).endVertex();
-			bufferBuilder.vertex(x2, y1, 0).uv(u2, v1).endVertex();
+			bufferBuilder.vertex(matrix, (float)x1, (float)y1, 0).uv(u1, v1).endVertex();
+			bufferBuilder.vertex(matrix, (float)x1, (float)y2, 0).uv(u1, v2).endVertex();
+			bufferBuilder.vertex(matrix, (float)x2, (float)y2, 0).uv(u2, v2).endVertex();
+			bufferBuilder.vertex(matrix, (float)x2, (float)y1, 0).uv(u2, v1).endVertex();
 			BufferUploader.drawWithShader(bufferBuilder.end());
 		}
 	}

--- a/forge/1.19.2-mapping/src/main/java/org/mtr/mapping/mapper/ScreenExtension.java
+++ b/forge/1.19.2-mapping/src/main/java/org/mtr/mapping/mapper/ScreenExtension.java
@@ -49,6 +49,11 @@ public class ScreenExtension extends ScreenAbstractMapping {
 		addRenderableWidget(child.data);
 	}
 
+	@MappedMethod
+	public final void addSelectableChild(ClickableWidget child) {
+		addWidget(child.data);
+	}
+
 	@Deprecated
 	@Override
 	public final boolean mouseScrolled(double mouseX, double mouseY, double amount) {

--- a/forge/1.19.4-mapping/src/main/java/org/mtr/mapping/mapper/GuiDrawing.java
+++ b/forge/1.19.4-mapping/src/main/java/org/mtr/mapping/mapper/GuiDrawing.java
@@ -3,6 +3,7 @@ package org.mtr.mapping.mapper;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.*;
 import net.minecraft.client.renderer.GameRenderer;
+import org.joml.Matrix4f;
 import org.mtr.mapping.annotation.MappedMethod;
 import org.mtr.mapping.holder.Identifier;
 import org.mtr.mapping.tool.ColorHelper;
@@ -11,13 +12,17 @@ import org.mtr.mapping.tool.DummyClass;
 public final class GuiDrawing extends DummyClass {
 
 	private BufferBuilder bufferBuilder;
+	private Matrix4f matrix;
+	private final GraphicsHolder graphicsHolder;
 
 	@MappedMethod
 	public GuiDrawing(GraphicsHolder graphicsHolder) {
+		this.graphicsHolder = graphicsHolder;
 	}
 
 	@MappedMethod
 	public void beginDrawingRectangle() {
+		matrix = graphicsHolder.matrixStack == null ? null : graphicsHolder.matrixStack.last().pose();
 		bufferBuilder = Tesselator.getInstance().getBuilder();
 		RenderSystem.enableBlend();
 		RenderSystem.setShader(GameRenderer::getPositionColorShader);
@@ -26,12 +31,12 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void drawRectangle(double x1, double y1, double x2, double y2, int color) {
-		if (bufferBuilder != null) {
+		if (matrix != null && bufferBuilder != null) {
 			ColorHelper.unpackColor(color, (a, r, g, b) -> {
-				bufferBuilder.vertex(x1, y1, 0).color(r, g, b, a).endVertex();
-				bufferBuilder.vertex(x1, y2, 0).color(r, g, b, a).endVertex();
-				bufferBuilder.vertex(x2, y2, 0).color(r, g, b, a).endVertex();
-				bufferBuilder.vertex(x2, y1, 0).color(r, g, b, a).endVertex();
+				bufferBuilder.vertex(matrix, (float)x1, (float)y1, 0).color(r, g, b, a).endVertex();
+				bufferBuilder.vertex(matrix, (float)x1, (float)y2, 0).color(r, g, b, a).endVertex();
+				bufferBuilder.vertex(matrix, (float)x2, (float)y2, 0).color(r, g, b, a).endVertex();
+				bufferBuilder.vertex(matrix, (float)x2, (float)y1, 0).color(r, g, b, a).endVertex();
 			});
 		}
 	}
@@ -44,6 +49,7 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void beginDrawingTexture(Identifier identifier) {
+		matrix = graphicsHolder.matrixStack == null ? null : graphicsHolder.matrixStack.last().pose();
 		bufferBuilder = Tesselator.getInstance().getBuilder();
 		RenderSystem.setShaderTexture(0, identifier.data);
 		RenderSystem.enableDepthTest();
@@ -52,12 +58,12 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void drawTexture(double x1, double y1, double x2, double y2, float u1, float v1, float u2, float v2) {
-		if (bufferBuilder != null) {
+		if (matrix != null && bufferBuilder != null) {
 			bufferBuilder.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_TEX);
-			bufferBuilder.vertex(x1, y1, 0).uv(u1, v1).endVertex();
-			bufferBuilder.vertex(x1, y2, 0).uv(u1, v2).endVertex();
-			bufferBuilder.vertex(x2, y2, 0).uv(u2, v2).endVertex();
-			bufferBuilder.vertex(x2, y1, 0).uv(u2, v1).endVertex();
+			bufferBuilder.vertex(matrix, (float)x1, (float)y1, 0).uv(u1, v1).endVertex();
+			bufferBuilder.vertex(matrix, (float)x1, (float)y2, 0).uv(u1, v2).endVertex();
+			bufferBuilder.vertex(matrix, (float)x2, (float)y2, 0).uv(u2, v2).endVertex();
+			bufferBuilder.vertex(matrix, (float)x2, (float)y1, 0).uv(u2, v1).endVertex();
 			BufferUploader.drawWithShader(bufferBuilder.end());
 		}
 	}

--- a/forge/1.19.4-mapping/src/main/java/org/mtr/mapping/mapper/ScreenExtension.java
+++ b/forge/1.19.4-mapping/src/main/java/org/mtr/mapping/mapper/ScreenExtension.java
@@ -49,6 +49,11 @@ public class ScreenExtension extends ScreenAbstractMapping {
 		addRenderableWidget(child.data);
 	}
 
+	@MappedMethod
+	public final void addSelectableChild(ClickableWidget child) {
+		addWidget(child.data);
+	}
+
 	@Deprecated
 	@Override
 	public final boolean mouseScrolled(double mouseX, double mouseY, double amount) {

--- a/forge/1.20.1-mapping/src/main/java/org/mtr/mapping/mapper/GuiDrawing.java
+++ b/forge/1.20.1-mapping/src/main/java/org/mtr/mapping/mapper/GuiDrawing.java
@@ -5,6 +5,7 @@ import com.mojang.blaze3d.vertex.*;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.RenderType;
+import org.joml.Matrix4f;
 import org.mtr.mapping.annotation.MappedMethod;
 import org.mtr.mapping.holder.Identifier;
 import org.mtr.mapping.tool.ColorHelper;
@@ -15,6 +16,7 @@ public final class GuiDrawing extends DummyClass {
 	private VertexConsumer vertexConsumer;
 	private GuiGraphics drawContext;
 	private BufferBuilder bufferBuilder;
+	private Matrix4f matrix;
 	private final GraphicsHolder graphicsHolder;
 
 	@MappedMethod
@@ -24,18 +26,19 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void beginDrawingRectangle() {
+		matrix = graphicsHolder.matrixStack == null ? null : graphicsHolder.matrixStack.last().pose();
 		vertexConsumer = graphicsHolder.vertexConsumerProvider == null ? null : graphicsHolder.vertexConsumerProvider.getBuffer(RenderType.gui());
 		drawContext = graphicsHolder.drawContext;
 	}
 
 	@MappedMethod
 	public void drawRectangle(double x1, double y1, double x2, double y2, int color) {
-		if (vertexConsumer != null && drawContext != null) {
+		if (matrix != null && vertexConsumer != null && drawContext != null) {
 			ColorHelper.unpackColor(color, (a, r, g, b) -> {
-				vertexConsumer.vertex(x1, y1, 0).color(r, g, b, a).endVertex();
-				vertexConsumer.vertex(x1, y2, 0).color(r, g, b, a).endVertex();
-				vertexConsumer.vertex(x2, y2, 0).color(r, g, b, a).endVertex();
-				vertexConsumer.vertex(x2, y1, 0).color(r, g, b, a).endVertex();
+				vertexConsumer.vertex(matrix, (float)x1, (float)y1, 0).color(r, g, b, a).endVertex();
+				vertexConsumer.vertex(matrix, (float)x1, (float)y2, 0).color(r, g, b, a).endVertex();
+				vertexConsumer.vertex(matrix, (float)x2, (float)y2, 0).color(r, g, b, a).endVertex();
+				vertexConsumer.vertex(matrix, (float)x2, (float)y1, 0).color(r, g, b, a).endVertex();
 			});
 		}
 	}
@@ -49,6 +52,7 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void beginDrawingTexture(Identifier identifier) {
+		matrix = graphicsHolder.matrixStack == null ? null : graphicsHolder.matrixStack.last().pose();
 		bufferBuilder = Tesselator.getInstance().getBuilder();
 		RenderSystem.setShaderTexture(0, identifier.data);
 		RenderSystem.enableDepthTest();
@@ -58,11 +62,11 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void drawTexture(double x1, double y1, double x2, double y2, float u1, float v1, float u2, float v2) {
-		if (bufferBuilder != null) {
-			bufferBuilder.vertex(x1, y1, 0).uv(u1, v1).endVertex();
-			bufferBuilder.vertex(x1, y2, 0).uv(u1, v2).endVertex();
-			bufferBuilder.vertex(x2, y2, 0).uv(u2, v2).endVertex();
-			bufferBuilder.vertex(x2, y1, 0).uv(u2, v1).endVertex();
+		if (matrix != null && bufferBuilder != null) {
+			bufferBuilder.vertex(matrix, (float)x1, (float)y1, 0).uv(u1, v1).endVertex();
+			bufferBuilder.vertex(matrix, (float)x1, (float)y2, 0).uv(u1, v2).endVertex();
+			bufferBuilder.vertex(matrix, (float)x2, (float)y2, 0).uv(u2, v2).endVertex();
+			bufferBuilder.vertex(matrix, (float)x2, (float)y1, 0).uv(u2, v1).endVertex();
 		}
 	}
 

--- a/forge/1.20.1-mapping/src/main/java/org/mtr/mapping/mapper/ScreenExtension.java
+++ b/forge/1.20.1-mapping/src/main/java/org/mtr/mapping/mapper/ScreenExtension.java
@@ -49,6 +49,11 @@ public class ScreenExtension extends ScreenAbstractMapping {
 		addRenderableWidget(child.data);
 	}
 
+	@MappedMethod
+	public final void addSelectableChild(ClickableWidget child) {
+		addWidget(child.data);
+	}
+
 	@Deprecated
 	@Override
 	public final boolean mouseScrolled(double mouseX, double mouseY, double verticalAmount) {

--- a/forge/1.20.4-mapping/src/main/java/org/mtr/mapping/mapper/GuiDrawing.java
+++ b/forge/1.20.4-mapping/src/main/java/org/mtr/mapping/mapper/GuiDrawing.java
@@ -5,6 +5,7 @@ import com.mojang.blaze3d.vertex.*;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.RenderType;
+import org.joml.Matrix4f;
 import org.mtr.mapping.annotation.MappedMethod;
 import org.mtr.mapping.holder.Identifier;
 import org.mtr.mapping.tool.ColorHelper;
@@ -15,6 +16,7 @@ public final class GuiDrawing extends DummyClass {
 	private VertexConsumer vertexConsumer;
 	private GuiGraphics drawContext;
 	private BufferBuilder bufferBuilder;
+	private Matrix4f matrix;
 	private final GraphicsHolder graphicsHolder;
 
 	@MappedMethod
@@ -24,18 +26,19 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void beginDrawingRectangle() {
+		matrix = graphicsHolder.matrixStack == null ? null : graphicsHolder.matrixStack.last().pose();
 		vertexConsumer = graphicsHolder.vertexConsumerProvider == null ? null : graphicsHolder.vertexConsumerProvider.getBuffer(RenderType.gui());
 		drawContext = graphicsHolder.drawContext;
 	}
 
 	@MappedMethod
 	public void drawRectangle(double x1, double y1, double x2, double y2, int color) {
-		if (vertexConsumer != null && drawContext != null) {
+		if (matrix != null && vertexConsumer != null && drawContext != null) {
 			ColorHelper.unpackColor(color, (a, r, g, b) -> {
-				vertexConsumer.vertex(x1, y1, 0).color(r, g, b, a).endVertex();
-				vertexConsumer.vertex(x1, y2, 0).color(r, g, b, a).endVertex();
-				vertexConsumer.vertex(x2, y2, 0).color(r, g, b, a).endVertex();
-				vertexConsumer.vertex(x2, y1, 0).color(r, g, b, a).endVertex();
+				vertexConsumer.vertex(matrix, (float)x1, (float)y1, 0).color(r, g, b, a).endVertex();
+				vertexConsumer.vertex(matrix, (float)x1, (float)y2, 0).color(r, g, b, a).endVertex();
+				vertexConsumer.vertex(matrix, (float)x2, (float)y2, 0).color(r, g, b, a).endVertex();
+				vertexConsumer.vertex(matrix, (float)x2, (float)y1, 0).color(r, g, b, a).endVertex();
 			});
 		}
 	}
@@ -49,6 +52,7 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void beginDrawingTexture(Identifier identifier) {
+		matrix = graphicsHolder.matrixStack == null ? null : graphicsHolder.matrixStack.last().pose();
 		bufferBuilder = Tesselator.getInstance().getBuilder();
 		RenderSystem.setShaderTexture(0, identifier.data);
 		RenderSystem.enableDepthTest();
@@ -58,11 +62,11 @@ public final class GuiDrawing extends DummyClass {
 
 	@MappedMethod
 	public void drawTexture(double x1, double y1, double x2, double y2, float u1, float v1, float u2, float v2) {
-		if (bufferBuilder != null) {
-			bufferBuilder.vertex(x1, y1, 0).uv(u1, v1).endVertex();
-			bufferBuilder.vertex(x1, y2, 0).uv(u1, v2).endVertex();
-			bufferBuilder.vertex(x2, y2, 0).uv(u2, v2).endVertex();
-			bufferBuilder.vertex(x2, y1, 0).uv(u2, v1).endVertex();
+		if (matrix != null && bufferBuilder != null) {
+			bufferBuilder.vertex(matrix, (float)x1, (float)y1, 0).uv(u1, v1).endVertex();
+			bufferBuilder.vertex(matrix, (float)x1, (float)y2, 0).uv(u1, v2).endVertex();
+			bufferBuilder.vertex(matrix, (float)x2, (float)y2, 0).uv(u2, v2).endVertex();
+			bufferBuilder.vertex(matrix, (float)x2, (float)y1, 0).uv(u2, v1).endVertex();
 		}
 	}
 

--- a/forge/1.20.4-mapping/src/main/java/org/mtr/mapping/mapper/ScreenExtension.java
+++ b/forge/1.20.4-mapping/src/main/java/org/mtr/mapping/mapper/ScreenExtension.java
@@ -54,6 +54,11 @@ public class ScreenExtension extends ScreenAbstractMapping {
 		addRenderableWidget(child.data);
 	}
 
+	@MappedMethod
+	public final void addSelectableChild(ClickableWidget child) {
+		addWidget(child.data);
+	}
+
 	@Deprecated
 	@Override
 	public final boolean mouseScrolled(double mouseX, double mouseY, double horizontalAmount, double verticalAmount) {


### PR DESCRIPTION
This PR:
- Adds the `addSelectableChild` method in ScreenExtension
- - This method is used to register a widget, without Minecraft automatically rendering them on the screen.
- Apply matrix in GuiDrawing
- - Matrix was not applied in GuiDrawing previously, which means you can't use it to do any kind of transformation when rendering stuff to the Screen.
- - This fixes a fair amount of issue with text overlapping (Text appearing in-front of GuiDrawing stuff even when they shouldn't), particularly on Dashboard screens.