### PR TITLE
Fix getUpdateTag not calling super on Forge 1.16.5

### DIFF
--- a/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/mapper/BlockEntityExtension.java
+++ b/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/mapper/BlockEntityExtension.java
@@ -41,7 +41,7 @@ public abstract class BlockEntityExtension extends BlockEntityAbstractMapping im
 	@Deprecated
 	@Override
 	public final CompoundNBT getUpdateTag() {
-		final CompoundNBT compoundTag = new CompoundNBT();
+		final CompoundNBT compoundTag = super.getUpdateTag();
 		writeCompoundTag(new CompoundTag(compoundTag));
 		return compoundTag;
 	}


### PR DESCRIPTION
This causes block entity data to not get synced properly to the client
Fix https://github.com/Minecraft-Transit-Railway/Minecraft-Transit-Railway/issues/1151