### PR TITLE
Model loading-related changes

### DIFF
--- a/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -25,6 +25,10 @@ public final class OptimizedModel extends DummyClass {
 	@MappedMethod
 	public OptimizedModel(OptimizedModel... optimizedModels) {
 	}
+	
+	@MappedMethod
+	public void close() {
+	}
 
 	public static final class MaterialGroup {
 

--- a/fabric/1.17.1-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/fabric/1.17.1-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -65,7 +65,7 @@ public final class OptimizedModel extends DummyClass {
 		return new OptimizedModel(uploadedParts);
 	}
 
-	private OptimizedModel(List<VertexArray> uploadedParts) {
+	public OptimizedModel(List<VertexArray> uploadedParts) {
 		this.uploadedParts = uploadedParts;
 	}
 
@@ -75,6 +75,11 @@ public final class OptimizedModel extends DummyClass {
 		for (final OptimizedModel optimizedModel : optimizedModels) {
 			uploadedParts.addAll(optimizedModel.uploadedParts);
 		}
+	}
+	
+	@MappedMethod
+	public void close() {
+		uploadedParts.forEach(VertexArray::close);
 	}
 
 	public static final class MaterialGroup {

--- a/fabric/1.17.1-mapping/src/main/java/org/mtr/mapping/render/object/VertexArray.java
+++ b/fabric/1.17.1-mapping/src/main/java/org/mtr/mapping/render/object/VertexArray.java
@@ -27,6 +27,13 @@ public final class VertexArray implements Closeable {
 		mesh.indexBuffer.bind(GL33.GL_ELEMENT_ARRAY_BUFFER);
 		unbind();
 	}
+	
+	public VertexArray(VertexArray other, MaterialProperties materialProperties) {
+		this.id = other.id;
+		this.materialProperties = materialProperties;
+		this.indexBuffer = other.indexBuffer;
+		this.mapping = other.mapping;
+	}
 
 	public void bind() {
 		GlStateTracker.assertProtected();

--- a/fabric/1.18.2-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/fabric/1.18.2-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -65,7 +65,7 @@ public final class OptimizedModel extends DummyClass {
 		return new OptimizedModel(uploadedParts);
 	}
 
-	private OptimizedModel(List<VertexArray> uploadedParts) {
+	public OptimizedModel(List<VertexArray> uploadedParts) {
 		this.uploadedParts = uploadedParts;
 	}
 
@@ -75,6 +75,11 @@ public final class OptimizedModel extends DummyClass {
 		for (final OptimizedModel optimizedModel : optimizedModels) {
 			uploadedParts.addAll(optimizedModel.uploadedParts);
 		}
+	}
+	
+	@MappedMethod
+	public void close() {
+		uploadedParts.forEach(VertexArray::close);
 	}
 
 	public static final class MaterialGroup {

--- a/fabric/1.18.2-mapping/src/main/java/org/mtr/mapping/render/object/VertexArray.java
+++ b/fabric/1.18.2-mapping/src/main/java/org/mtr/mapping/render/object/VertexArray.java
@@ -27,6 +27,13 @@ public final class VertexArray implements Closeable {
 		mesh.indexBuffer.bind(GL33.GL_ELEMENT_ARRAY_BUFFER);
 		unbind();
 	}
+	
+	public VertexArray(VertexArray other, MaterialProperties materialProperties) {
+		this.id = other.id;
+		this.materialProperties = materialProperties;
+		this.indexBuffer = other.indexBuffer;
+		this.mapping = other.mapping;
+	}
 
 	public void bind() {
 		GlStateTracker.assertProtected();

--- a/fabric/1.19.2-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/fabric/1.19.2-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -65,7 +65,7 @@ public final class OptimizedModel extends DummyClass {
 		return new OptimizedModel(uploadedParts);
 	}
 
-	private OptimizedModel(List<VertexArray> uploadedParts) {
+	public OptimizedModel(List<VertexArray> uploadedParts) {
 		this.uploadedParts = uploadedParts;
 	}
 
@@ -75,6 +75,11 @@ public final class OptimizedModel extends DummyClass {
 		for (final OptimizedModel optimizedModel : optimizedModels) {
 			uploadedParts.addAll(optimizedModel.uploadedParts);
 		}
+	}
+	
+	@MappedMethod
+	public void close() {
+		uploadedParts.forEach(VertexArray::close);
 	}
 
 	public static final class MaterialGroup {

--- a/fabric/1.19.2-mapping/src/main/java/org/mtr/mapping/render/object/VertexArray.java
+++ b/fabric/1.19.2-mapping/src/main/java/org/mtr/mapping/render/object/VertexArray.java
@@ -27,6 +27,13 @@ public final class VertexArray implements Closeable {
 		mesh.indexBuffer.bind(GL33.GL_ELEMENT_ARRAY_BUFFER);
 		unbind();
 	}
+	
+	public VertexArray(VertexArray other, MaterialProperties materialProperties) {
+		this.id = other.id;
+		this.materialProperties = materialProperties;
+		this.indexBuffer = other.indexBuffer;
+		this.mapping = other.mapping;
+	}
 
 	public void bind() {
 		GlStateTracker.assertProtected();

--- a/fabric/1.19.4-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/fabric/1.19.4-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -65,7 +65,7 @@ public final class OptimizedModel extends DummyClass {
 		return new OptimizedModel(uploadedParts);
 	}
 
-	private OptimizedModel(List<VertexArray> uploadedParts) {
+	public OptimizedModel(List<VertexArray> uploadedParts) {
 		this.uploadedParts = uploadedParts;
 	}
 
@@ -75,6 +75,11 @@ public final class OptimizedModel extends DummyClass {
 		for (final OptimizedModel optimizedModel : optimizedModels) {
 			uploadedParts.addAll(optimizedModel.uploadedParts);
 		}
+	}
+	
+	@MappedMethod
+	public void close() {
+		uploadedParts.forEach(VertexArray::close);
 	}
 
 	public static final class MaterialGroup {

--- a/fabric/1.19.4-mapping/src/main/java/org/mtr/mapping/render/object/VertexArray.java
+++ b/fabric/1.19.4-mapping/src/main/java/org/mtr/mapping/render/object/VertexArray.java
@@ -27,6 +27,13 @@ public final class VertexArray implements Closeable {
 		mesh.indexBuffer.bind(GL33.GL_ELEMENT_ARRAY_BUFFER);
 		unbind();
 	}
+	
+	public VertexArray(VertexArray other, MaterialProperties materialProperties) {
+		this.id = other.id;
+		this.materialProperties = materialProperties;
+		this.indexBuffer = other.indexBuffer;
+		this.mapping = other.mapping;
+	}
 
 	public void bind() {
 		GlStateTracker.assertProtected();

--- a/fabric/1.20.1-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/fabric/1.20.1-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -65,7 +65,7 @@ public final class OptimizedModel extends DummyClass {
 		return new OptimizedModel(uploadedParts);
 	}
 
-	private OptimizedModel(List<VertexArray> uploadedParts) {
+	public OptimizedModel(List<VertexArray> uploadedParts) {
 		this.uploadedParts = uploadedParts;
 	}
 
@@ -75,6 +75,11 @@ public final class OptimizedModel extends DummyClass {
 		for (final OptimizedModel optimizedModel : optimizedModels) {
 			uploadedParts.addAll(optimizedModel.uploadedParts);
 		}
+	}
+	
+	@MappedMethod
+	public void close() {
+		uploadedParts.forEach(VertexArray::close);
 	}
 
 	public static final class MaterialGroup {

--- a/fabric/1.20.1-mapping/src/main/java/org/mtr/mapping/render/object/VertexArray.java
+++ b/fabric/1.20.1-mapping/src/main/java/org/mtr/mapping/render/object/VertexArray.java
@@ -27,6 +27,13 @@ public final class VertexArray implements Closeable {
 		mesh.indexBuffer.bind(GL33.GL_ELEMENT_ARRAY_BUFFER);
 		unbind();
 	}
+	
+	public VertexArray(VertexArray other, MaterialProperties materialProperties) {
+		this.id = other.id;
+		this.materialProperties = materialProperties;
+		this.indexBuffer = other.indexBuffer;
+		this.mapping = other.mapping;
+	}
 
 	public void bind() {
 		GlStateTracker.assertProtected();

--- a/fabric/1.20.4-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/fabric/1.20.4-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -65,7 +65,7 @@ public final class OptimizedModel extends DummyClass {
 		return new OptimizedModel(uploadedParts);
 	}
 
-	private OptimizedModel(List<VertexArray> uploadedParts) {
+	public OptimizedModel(List<VertexArray> uploadedParts) {
 		this.uploadedParts = uploadedParts;
 	}
 
@@ -75,6 +75,11 @@ public final class OptimizedModel extends DummyClass {
 		for (final OptimizedModel optimizedModel : optimizedModels) {
 			uploadedParts.addAll(optimizedModel.uploadedParts);
 		}
+	}
+	
+	@MappedMethod
+	public void close() {
+		uploadedParts.forEach(VertexArray::close);
 	}
 
 	public static final class MaterialGroup {

--- a/fabric/1.20.4-mapping/src/main/java/org/mtr/mapping/render/object/VertexArray.java
+++ b/fabric/1.20.4-mapping/src/main/java/org/mtr/mapping/render/object/VertexArray.java
@@ -27,6 +27,13 @@ public final class VertexArray implements Closeable {
 		mesh.indexBuffer.bind(GL33.GL_ELEMENT_ARRAY_BUFFER);
 		unbind();
 	}
+	
+	public VertexArray(VertexArray other, MaterialProperties materialProperties) {
+		this.id = other.id;
+		this.materialProperties = materialProperties;
+		this.indexBuffer = other.indexBuffer;
+		this.mapping = other.mapping;
+	}
 
 	public void bind() {
 		GlStateTracker.assertProtected();

--- a/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -25,6 +25,10 @@ public final class OptimizedModel extends DummyClass {
 	@MappedMethod
 	public OptimizedModel(OptimizedModel... optimizedModels) {
 	}
+	
+	@MappedMethod
+	public void close() {
+	}
 
 	public static final class MaterialGroup {
 

--- a/forge/1.17.1-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/forge/1.17.1-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -64,7 +64,7 @@ public final class OptimizedModel extends DummyClass {
 		return new OptimizedModel(uploadedParts);
 	}
 
-	private OptimizedModel(List<VertexArray> uploadedParts) {
+	public OptimizedModel(List<VertexArray> uploadedParts) {
 		this.uploadedParts = uploadedParts;
 	}
 
@@ -74,6 +74,11 @@ public final class OptimizedModel extends DummyClass {
 		for (final OptimizedModel optimizedModel : optimizedModels) {
 			uploadedParts.addAll(optimizedModel.uploadedParts);
 		}
+	}
+	
+	@MappedMethod
+	public void close() {
+		uploadedParts.forEach(VertexArray::close);
 	}
 
 	public static final class MaterialGroup {

--- a/forge/1.17.1-mapping/src/main/java/org/mtr/mapping/render/object/VertexArray.java
+++ b/forge/1.17.1-mapping/src/main/java/org/mtr/mapping/render/object/VertexArray.java
@@ -27,6 +27,13 @@ public final class VertexArray implements Closeable {
 		mesh.indexBuffer.bind(GL33.GL_ELEMENT_ARRAY_BUFFER);
 		unbind();
 	}
+	
+	public VertexArray(VertexArray other, MaterialProperties materialProperties) {
+		this.id = other.id;
+		this.materialProperties = materialProperties;
+		this.indexBuffer = other.indexBuffer;
+		this.mapping = other.mapping;
+	}
 
 	public void bind() {
 		GlStateTracker.assertProtected();

--- a/forge/1.18.2-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/forge/1.18.2-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -64,7 +64,7 @@ public final class OptimizedModel extends DummyClass {
 		return new OptimizedModel(uploadedParts);
 	}
 
-	private OptimizedModel(List<VertexArray> uploadedParts) {
+	public OptimizedModel(List<VertexArray> uploadedParts) {
 		this.uploadedParts = uploadedParts;
 	}
 
@@ -74,6 +74,11 @@ public final class OptimizedModel extends DummyClass {
 		for (final OptimizedModel optimizedModel : optimizedModels) {
 			uploadedParts.addAll(optimizedModel.uploadedParts);
 		}
+	}
+	
+	@MappedMethod
+	public void close() {
+		uploadedParts.forEach(VertexArray::close);
 	}
 
 	public static final class MaterialGroup {

--- a/forge/1.18.2-mapping/src/main/java/org/mtr/mapping/render/object/VertexArray.java
+++ b/forge/1.18.2-mapping/src/main/java/org/mtr/mapping/render/object/VertexArray.java
@@ -27,6 +27,13 @@ public final class VertexArray implements Closeable {
 		mesh.indexBuffer.bind(GL33.GL_ELEMENT_ARRAY_BUFFER);
 		unbind();
 	}
+	
+	public VertexArray(VertexArray other, MaterialProperties materialProperties) {
+		this.id = other.id;
+		this.materialProperties = materialProperties;
+		this.indexBuffer = other.indexBuffer;
+		this.mapping = other.mapping;
+	}
 
 	public void bind() {
 		GlStateTracker.assertProtected();

--- a/forge/1.19.2-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/forge/1.19.2-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -64,7 +64,7 @@ public final class OptimizedModel extends DummyClass {
 		return new OptimizedModel(uploadedParts);
 	}
 
-	private OptimizedModel(List<VertexArray> uploadedParts) {
+	public OptimizedModel(List<VertexArray> uploadedParts) {
 		this.uploadedParts = uploadedParts;
 	}
 
@@ -74,6 +74,11 @@ public final class OptimizedModel extends DummyClass {
 		for (final OptimizedModel optimizedModel : optimizedModels) {
 			uploadedParts.addAll(optimizedModel.uploadedParts);
 		}
+	}
+	
+	@MappedMethod
+	public void close() {
+		uploadedParts.forEach(VertexArray::close);
 	}
 
 	public static final class MaterialGroup {

--- a/forge/1.19.2-mapping/src/main/java/org/mtr/mapping/render/object/VertexArray.java
+++ b/forge/1.19.2-mapping/src/main/java/org/mtr/mapping/render/object/VertexArray.java
@@ -27,6 +27,13 @@ public final class VertexArray implements Closeable {
 		mesh.indexBuffer.bind(GL33.GL_ELEMENT_ARRAY_BUFFER);
 		unbind();
 	}
+	
+	public VertexArray(VertexArray other, MaterialProperties materialProperties) {
+		this.id = other.id;
+		this.materialProperties = materialProperties;
+		this.indexBuffer = other.indexBuffer;
+		this.mapping = other.mapping;
+	}
 
 	public void bind() {
 		GlStateTracker.assertProtected();

--- a/forge/1.19.4-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/forge/1.19.4-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -65,7 +65,7 @@ public final class OptimizedModel extends DummyClass {
 		return new OptimizedModel(uploadedParts);
 	}
 
-	private OptimizedModel(List<VertexArray> uploadedParts) {
+	public OptimizedModel(List<VertexArray> uploadedParts) {
 		this.uploadedParts = uploadedParts;
 	}
 
@@ -75,6 +75,11 @@ public final class OptimizedModel extends DummyClass {
 		for (final OptimizedModel optimizedModel : optimizedModels) {
 			uploadedParts.addAll(optimizedModel.uploadedParts);
 		}
+	}
+	
+	@MappedMethod
+	public void close() {
+		uploadedParts.forEach(VertexArray::close);
 	}
 
 	public static final class MaterialGroup {

--- a/forge/1.19.4-mapping/src/main/java/org/mtr/mapping/render/object/VertexArray.java
+++ b/forge/1.19.4-mapping/src/main/java/org/mtr/mapping/render/object/VertexArray.java
@@ -27,6 +27,13 @@ public final class VertexArray implements Closeable {
 		mesh.indexBuffer.bind(GL33.GL_ELEMENT_ARRAY_BUFFER);
 		unbind();
 	}
+	
+	public VertexArray(VertexArray other, MaterialProperties materialProperties) {
+		this.id = other.id;
+		this.materialProperties = materialProperties;
+		this.indexBuffer = other.indexBuffer;
+		this.mapping = other.mapping;
+	}
 
 	public void bind() {
 		GlStateTracker.assertProtected();

--- a/forge/1.20.1-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/forge/1.20.1-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -65,7 +65,7 @@ public final class OptimizedModel extends DummyClass {
 		return new OptimizedModel(uploadedParts);
 	}
 
-	private OptimizedModel(List<VertexArray> uploadedParts) {
+	public OptimizedModel(List<VertexArray> uploadedParts) {
 		this.uploadedParts = uploadedParts;
 	}
 
@@ -75,6 +75,11 @@ public final class OptimizedModel extends DummyClass {
 		for (final OptimizedModel optimizedModel : optimizedModels) {
 			uploadedParts.addAll(optimizedModel.uploadedParts);
 		}
+	}
+	
+	@MappedMethod
+	public void close() {
+		uploadedParts.forEach(VertexArray::close);
 	}
 
 	public static final class MaterialGroup {

--- a/forge/1.20.1-mapping/src/main/java/org/mtr/mapping/render/object/VertexArray.java
+++ b/forge/1.20.1-mapping/src/main/java/org/mtr/mapping/render/object/VertexArray.java
@@ -27,6 +27,13 @@ public final class VertexArray implements Closeable {
 		mesh.indexBuffer.bind(GL33.GL_ELEMENT_ARRAY_BUFFER);
 		unbind();
 	}
+	
+	public VertexArray(VertexArray other, MaterialProperties materialProperties) {
+		this.id = other.id;
+		this.materialProperties = materialProperties;
+		this.indexBuffer = other.indexBuffer;
+		this.mapping = other.mapping;
+	}
 
 	public void bind() {
 		GlStateTracker.assertProtected();

--- a/forge/1.20.4-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/forge/1.20.4-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -65,7 +65,7 @@ public final class OptimizedModel extends DummyClass {
 		return new OptimizedModel(uploadedParts);
 	}
 
-	private OptimizedModel(List<VertexArray> uploadedParts) {
+	public OptimizedModel(List<VertexArray> uploadedParts) {
 		this.uploadedParts = uploadedParts;
 	}
 
@@ -75,6 +75,11 @@ public final class OptimizedModel extends DummyClass {
 		for (final OptimizedModel optimizedModel : optimizedModels) {
 			uploadedParts.addAll(optimizedModel.uploadedParts);
 		}
+	}
+	
+	@MappedMethod
+	public void close() {
+		uploadedParts.forEach(VertexArray::close);
 	}
 
 	public static final class MaterialGroup {

--- a/forge/1.20.4-mapping/src/main/java/org/mtr/mapping/render/object/VertexArray.java
+++ b/forge/1.20.4-mapping/src/main/java/org/mtr/mapping/render/object/VertexArray.java
@@ -27,6 +27,13 @@ public final class VertexArray implements Closeable {
 		mesh.indexBuffer.bind(GL33.GL_ELEMENT_ARRAY_BUFFER);
 		unbind();
 	}
+	
+	public VertexArray(VertexArray other, MaterialProperties materialProperties) {
+		this.id = other.id;
+		this.materialProperties = materialProperties;
+		this.indexBuffer = other.indexBuffer;
+		this.mapping = other.mapping;
+	}
 
 	public void bind() {
 		GlStateTracker.assertProtected();


### PR DESCRIPTION
- Add a constructor for VertexArray which merely copies the value from the other VertexArray
  - This is required to implement `copyForMaterialChanges()`, a method which makes a shallow copy of the vert arrays with a new MaterialProperties, allowing textures to be changed at runtime for uploaded model.
- Add `OptimizedModel.close()` to allow closing an OptimizedModel and freeing up resources, which was previously not possible and requires mixin to iterate through VertexArray and closing it.
- Make the constructor public for OptimizedModel to take in an existing VertexArray list.