### PR TITLE
Sync GPU OBJ mapping APIs across versions

### DIFF
--- a/common/src/test/java/org/mtr/mapping/test/AnalyzeResultsTest.java
+++ b/common/src/test/java/org/mtr/mapping/test/AnalyzeResultsTest.java
@@ -12,25 +12,42 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public final class AnalyzeResultsTest {
 
+	private static final Pattern FILE_NAME_PATTERN = Pattern.compile("^(fabric|forge)-([0-9.]+)\\.txt$");
+
 	@Test
 	public void validateMappedMethods() throws IOException {
-		String existingData = null;
+		final Map<String, Map<String, String>> mappedMethodsByVersion = new TreeMap<>();
 		final List<Executable> assertions = new ArrayList<>();
 
 		try (final DirectoryStream<Path> directoryStream = Files.newDirectoryStream(Paths.get("../build/mappedMethods"))) {
 			for (Path path : directoryStream) {
-				final String newData = FileUtils.readFileToString(path.toFile(), StandardCharsets.UTF_8);
-				if (existingData != null) {
-					final String finalExistingData = existingData;
-					assertions.add(() -> Assertions.assertEquals(finalExistingData, newData, path.getFileName().toString()));
-				}
-				existingData = newData;
+				final String fileName = path.getFileName().toString();
+				final Matcher matcher = FILE_NAME_PATTERN.matcher(fileName);
+				Assertions.assertTrue(matcher.matches(), "Unexpected mapped methods file: " + fileName);
+				final String loader = matcher.group(1);
+				final String version = matcher.group(2);
+				mappedMethodsByVersion.computeIfAbsent(version, ignored -> new HashMap<>()).put(loader, FileUtils.readFileToString(path.toFile(), StandardCharsets.UTF_8));
 			}
 		}
+
+		mappedMethodsByVersion.forEach((version, loaders) -> {
+			final String fabricData = loaders.get("fabric");
+			final String forgeData = loaders.get("forge");
+			assertions.add(() -> {
+				Assertions.assertNotNull(fabricData, version + " is missing fabric mapped methods");
+				Assertions.assertNotNull(forgeData, version + " is missing forge mapped methods");
+				Assertions.assertEquals(fabricData, forgeData, version + " fabric and forge mapped methods differ");
+			});
+		});
 
 		Assertions.assertAll(assertions);
 	}

--- a/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/mapper/GraphicsHolder.java
+++ b/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/mapper/GraphicsHolder.java
@@ -126,6 +126,11 @@ public final class GraphicsHolder extends DummyClass {
 	}
 
 	@MappedMethod
+	public org.mtr.mapping.holder.Matrix4f copyPositionMatrix() {
+		return matrixStack == null ? new org.mtr.mapping.holder.Matrix4f() : new org.mtr.mapping.holder.Matrix4f(matrixStack.peek().getModel());
+	}
+
+	@MappedMethod
 	public void drawText(MutableText mutableText, int x, int y, int color, boolean shadow, int light) {
 		if (matrixStack != null) {
 			final VertexConsumerProvider.Immediate immediate = VertexConsumerProvider.immediate(net.minecraft.client.render.Tessellator.getInstance().getBuffer());

--- a/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/render/batch/MaterialProperties.java
+++ b/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/render/batch/MaterialProperties.java
@@ -1,0 +1,55 @@
+package org.mtr.mapping.render.batch;
+
+import org.mtr.mapping.holder.Identifier;
+import org.mtr.mapping.mapper.OptimizedModel;
+import org.mtr.mapping.render.vertex.VertexAttributeState;
+
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+public final class MaterialProperties {
+
+	private Identifier texture;
+	public final OptimizedModel.ShaderType shaderType;
+	public final VertexAttributeState vertexAttributeState;
+	public final boolean translucent;
+	public final boolean writeDepthBuf;
+	public final boolean cutoutHack;
+
+	public MaterialProperties(OptimizedModel.ShaderType shaderType, Identifier texture, @Nullable Integer color) {
+		this.shaderType = shaderType;
+		this.texture = texture;
+		translucent = shaderType == OptimizedModel.ShaderType.TRANSLUCENT || shaderType == OptimizedModel.ShaderType.TRANSLUCENT_BRIGHT || shaderType == OptimizedModel.ShaderType.TRANSLUCENT_GLOWING;
+		writeDepthBuf = shaderType != OptimizedModel.ShaderType.TRANSLUCENT_GLOWING;
+		cutoutHack = shaderType == OptimizedModel.ShaderType.CUTOUT_GLOWING;
+		vertexAttributeState = new VertexAttributeState(color, shaderType == OptimizedModel.ShaderType.CUTOUT_BRIGHT || shaderType == OptimizedModel.ShaderType.TRANSLUCENT_BRIGHT ? 15 << 4 | 15 << 20 : null);
+	}
+
+	public void setupCompositeState() {
+	}
+
+	public Identifier getTexture() {
+		return texture;
+	}
+
+	public void setTexture(Identifier texture) {
+		this.texture = texture;
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+		if (!(object instanceof MaterialProperties)) {
+			return false;
+		}
+		final MaterialProperties that = (MaterialProperties) object;
+		return shaderType == that.shaderType && Objects.equals(texture, that.texture) && Objects.equals(vertexAttributeState, that.vertexAttributeState);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(texture, shaderType, vertexAttributeState);
+	}
+}

--- a/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/render/model/Mesh.java
+++ b/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/render/model/Mesh.java
@@ -1,0 +1,25 @@
+package org.mtr.mapping.render.model;
+
+import org.mtr.mapping.render.batch.MaterialProperties;
+import org.mtr.mapping.render.object.IndexBuffer;
+import org.mtr.mapping.render.object.VertexBuffer;
+
+import java.io.Closeable;
+
+public final class Mesh implements Closeable {
+	public final VertexBuffer vertexBuffer;
+	public final IndexBuffer indexBuffer;
+	public final MaterialProperties materialProperties;
+
+	public Mesh(VertexBuffer vertexBuffer, IndexBuffer indexBuffer, MaterialProperties materialProperties) {
+		this.vertexBuffer = vertexBuffer;
+		this.indexBuffer = indexBuffer;
+		this.materialProperties = materialProperties;
+	}
+
+	@Override
+	public void close() {
+		vertexBuffer.close();
+		indexBuffer.close();
+	}
+}

--- a/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/render/model/RawMesh.java
+++ b/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/render/model/RawMesh.java
@@ -1,0 +1,61 @@
+package org.mtr.mapping.render.model;
+
+import org.mtr.mapping.holder.Vector3f;
+import org.mtr.mapping.mapper.OptimizedModel;
+import org.mtr.mapping.render.batch.MaterialProperties;
+import org.mtr.mapping.render.object.IndexBuffer;
+import org.mtr.mapping.render.object.VertexBuffer;
+import org.mtr.mapping.render.vertex.Vertex;
+import org.mtr.mapping.render.vertex.VertexAttributeMapping;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class RawMesh {
+	public final MaterialProperties materialProperties;
+	public final List<Vertex> vertices = new ArrayList<>();
+
+	public RawMesh(MaterialProperties materialProperties) {
+		this.materialProperties = materialProperties;
+	}
+
+	public RawMesh(OptimizedModel.ShaderType shaderType, RawMesh rawMesh) {
+		materialProperties = new MaterialProperties(shaderType, rawMesh.materialProperties.getTexture(), rawMesh.materialProperties.vertexAttributeState.color);
+		vertices.addAll(rawMesh.vertices);
+	}
+
+	public void append(RawMesh nextMesh) {
+		vertices.addAll(nextMesh.vertices);
+	}
+
+	public void applyTranslation(float x, float y, float z) {
+	}
+
+	public void applyRotation(Vector3f axis, float angle) {
+	}
+
+	public void applyScale(float x, float y, float z) {
+	}
+
+	public void applyMirror(boolean vx, boolean vy, boolean vz, boolean nx, boolean ny, boolean nz) {
+	}
+
+	public void applyUVMirror(boolean u, boolean v) {
+	}
+
+	public void generateNormals() {
+	}
+
+	public void distinct() {
+	}
+
+	public void triangulate() {
+	}
+
+	public void validateVertexIndex() {
+	}
+
+	public Mesh upload(VertexAttributeMapping vertexAttributeMapping) {
+		return new Mesh(new VertexBuffer(), new IndexBuffer(0), materialProperties);
+	}
+}

--- a/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/render/obj/AtlasManager.java
+++ b/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/render/obj/AtlasManager.java
@@ -1,0 +1,12 @@
+package org.mtr.mapping.render.obj;
+
+import org.mtr.mapping.holder.Identifier;
+import org.mtr.mapping.render.model.RawMesh;
+
+public final class AtlasManager {
+	public void load(Identifier atlasConfiguration) {
+	}
+
+	public void applyToMesh(RawMesh mesh) {
+	}
+}

--- a/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
+++ b/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
@@ -1,0 +1,15 @@
+package org.mtr.mapping.render.obj;
+
+import org.mtr.mapping.holder.Identifier;
+import org.mtr.mapping.render.model.RawMesh;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+public final class ObjModelLoader {
+	public static Map<String, List<RawMesh>> loadModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, AtlasManager atlasManager, boolean splitModel) {
+		return Collections.emptyMap();
+	}
+}

--- a/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/render/object/IndexBuffer.java
+++ b/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/render/object/IndexBuffer.java
@@ -1,0 +1,23 @@
+package org.mtr.mapping.render.object;
+
+import java.io.Closeable;
+
+public final class IndexBuffer implements Closeable {
+	public final int indexType = 0;
+	private final int vertexCount;
+
+	public IndexBuffer(int vertexCount) {
+		this.vertexCount = vertexCount;
+	}
+
+	public void bind(int target) {
+	}
+
+	public int getVertexCount() {
+		return vertexCount;
+	}
+
+	@Override
+	public void close() {
+	}
+}

--- a/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/render/object/InstancedDrawHelper.java
+++ b/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/render/object/InstancedDrawHelper.java
@@ -1,0 +1,26 @@
+package org.mtr.mapping.render.object;
+
+import org.mtr.mapping.render.vertex.VertexAttributeMapping;
+import org.mtr.mapping.render.vertex.VertexAttributeType;
+
+import java.nio.ByteBuffer;
+
+public final class InstancedDrawHelper {
+
+	public static boolean setupInstanceAttributes(VertexArray vertexArray, VertexBuffer instanceBuffer, VertexAttributeMapping mapping, VertexAttributeType... vertexAttributeTypes) {
+		return true;
+	}
+
+	public static void setupInstanceAttributePointers(VertexBuffer instanceBuffer, VertexAttributeMapping mapping, int instanceOffsetBytes, VertexAttributeType... vertexAttributeTypes) {
+	}
+
+	public static void uploadInstances(VertexBuffer instanceBuffer, ByteBuffer byteBuffer, int size) {
+		instanceBuffer.upload(byteBuffer);
+	}
+
+	public static void drawElementsInstanced(VertexArray vertexArray, int instanceCount) {
+	}
+
+	private InstancedDrawHelper() {
+	}
+}

--- a/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/render/object/VertexArray.java
+++ b/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/render/object/VertexArray.java
@@ -1,0 +1,38 @@
+package org.mtr.mapping.render.object;
+
+import org.mtr.mapping.render.batch.MaterialProperties;
+import org.mtr.mapping.render.model.Mesh;
+import org.mtr.mapping.render.vertex.VertexAttributeMapping;
+
+import java.io.Closeable;
+
+public final class VertexArray implements Closeable {
+	public final MaterialProperties materialProperties;
+	public final IndexBuffer indexBuffer;
+	public final VertexAttributeMapping mapping;
+
+	public VertexArray(Mesh mesh, VertexAttributeMapping mapping) {
+		materialProperties = mesh.materialProperties;
+		indexBuffer = mesh.indexBuffer;
+		this.mapping = mapping;
+	}
+
+	public VertexArray(VertexArray other, MaterialProperties materialProperties) {
+		this.materialProperties = materialProperties;
+		indexBuffer = other.indexBuffer;
+		mapping = other.mapping;
+	}
+
+	public void bind() {
+	}
+
+	public static void unbind() {
+	}
+
+	public void draw() {
+	}
+
+	@Override
+	public void close() {
+	}
+}

--- a/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/render/object/VertexBuffer.java
+++ b/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/render/object/VertexBuffer.java
@@ -1,0 +1,16 @@
+package org.mtr.mapping.render.object;
+
+import java.io.Closeable;
+import java.nio.ByteBuffer;
+
+public final class VertexBuffer implements Closeable {
+	public void bind(int target) {
+	}
+
+	public void upload(ByteBuffer byteBuffer) {
+	}
+
+	@Override
+	public void close() {
+	}
+}

--- a/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/render/shader/ShaderManager.java
+++ b/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/render/shader/ShaderManager.java
@@ -12,4 +12,7 @@ public final class ShaderManager {
 
 	public void setupShaderBatchState(MaterialProperties materialProperties) {
 	}
+
+	public void cleanupShaderBatchState() {
+	}
 }

--- a/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/render/shader/ShaderManager.java
+++ b/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/render/shader/ShaderManager.java
@@ -1,0 +1,15 @@
+package org.mtr.mapping.render.shader;
+
+import org.mtr.mapping.render.batch.MaterialProperties;
+
+public final class ShaderManager {
+	public void reloadShaders() {
+	}
+
+	public boolean isReady() {
+		return false;
+	}
+
+	public void setupShaderBatchState(MaterialProperties materialProperties) {
+	}
+}

--- a/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/render/tool/GlStateTracker.java
+++ b/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/render/tool/GlStateTracker.java
@@ -1,0 +1,20 @@
+package org.mtr.mapping.render.tool;
+
+public final class GlStateTracker {
+	public static void capture() {
+	}
+
+	public static void restore() {
+	}
+
+	public static void assertProtected() {
+	}
+
+	public static boolean supportVertexAttributeDivisor() {
+		return false;
+	}
+
+	public static boolean isGl4ES() {
+		return false;
+	}
+}

--- a/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/render/tool/Utilities.java
+++ b/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/render/tool/Utilities.java
@@ -1,0 +1,39 @@
+package org.mtr.mapping.render.tool;
+
+import org.mtr.mapping.holder.Matrix4f;
+import org.mtr.mapping.holder.Vector3f;
+
+import java.nio.FloatBuffer;
+
+public final class Utilities {
+	public static int exchangeLightmapUVBits(int light) {
+		return (light >>> 16) | (((short) light) << 16);
+	}
+
+	public static Matrix4f create() {
+		return new Matrix4f();
+	}
+
+	public static Matrix4f copy(Matrix4f matrix4f) {
+		return matrix4f;
+	}
+
+	public static void store(Matrix4f matrix4f, FloatBuffer buffer) {
+	}
+
+	public static Vector3f transformPosition(Matrix4f matrix4f, Vector3f src) {
+		return src;
+	}
+
+	public static Vector3f transformDirection(Matrix4f matrix4f, Vector3f src) {
+		return src;
+	}
+
+	public static Vector3f copy(Vector3f vector3f) {
+		return vector3f;
+	}
+
+	public static boolean canUseCustomShader() {
+		return false;
+	}
+}

--- a/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/render/vertex/Vertex.java
+++ b/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/render/vertex/Vertex.java
@@ -1,0 +1,10 @@
+package org.mtr.mapping.render.vertex;
+
+import org.mtr.mapping.holder.Vector3f;
+
+public final class Vertex {
+	public Vector3f position;
+	public Vector3f normal;
+	public float u;
+	public float v;
+}

--- a/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/render/vertex/VertexAttributeMapping.java
+++ b/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/render/vertex/VertexAttributeMapping.java
@@ -1,0 +1,62 @@
+package org.mtr.mapping.render.vertex;
+
+import org.mtr.mapping.render.object.VertexBuffer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public final class VertexAttributeMapping {
+
+	public final Map<VertexAttributeType, VertexAttributeSource> sources;
+	public final Map<VertexAttributeType, Integer> pointers = new HashMap<>();
+	public final int strideVertex;
+	public final int strideInstance;
+	public final int paddingVertex;
+	public final int paddingInstance;
+
+	private VertexAttributeMapping(Map<VertexAttributeType, VertexAttributeSource> sources) {
+		this.sources = sources;
+		int strideVertex = 0;
+		int strideInstance = 0;
+		for (final VertexAttributeType vertexAttributeType : VertexAttributeType.values()) {
+			switch (sources.get(vertexAttributeType)) {
+				case VERTEX_BUFFER:
+					pointers.put(vertexAttributeType, strideVertex);
+					strideVertex += vertexAttributeType.byteSize;
+					break;
+				case INSTANCE_BUFFER:
+					pointers.put(vertexAttributeType, strideInstance);
+					strideInstance += vertexAttributeType.byteSize;
+					break;
+				default:
+					break;
+			}
+		}
+		this.strideVertex = strideVertex;
+		this.strideInstance = strideInstance;
+		paddingVertex = 0;
+		paddingInstance = 0;
+	}
+
+	public void setupAttributesToVao(VertexBuffer vertexBuffer) {
+	}
+
+	public static class Builder {
+		private final HashMap<VertexAttributeType, VertexAttributeSource> sources = new HashMap<>();
+
+		public Builder() {
+			for (final VertexAttributeType vertexAttributeType : VertexAttributeType.values()) {
+				sources.put(vertexAttributeType, VertexAttributeSource.VERTEX_BUFFER);
+			}
+		}
+
+		public Builder set(VertexAttributeType vertexAttributeType, VertexAttributeSource vertexAttributeSource) {
+			sources.put(vertexAttributeType, vertexAttributeSource);
+			return this;
+		}
+
+		public VertexAttributeMapping build() {
+			return new VertexAttributeMapping(sources);
+		}
+	}
+}

--- a/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/render/vertex/VertexAttributeSource.java
+++ b/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/render/vertex/VertexAttributeSource.java
@@ -1,0 +1,5 @@
+package org.mtr.mapping.render.vertex;
+
+public enum VertexAttributeSource {
+	GLOBAL, VERTEX_BUFFER, INSTANCE_BUFFER
+}

--- a/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/render/vertex/VertexAttributeState.java
+++ b/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/render/vertex/VertexAttributeState.java
@@ -1,0 +1,45 @@
+package org.mtr.mapping.render.vertex;
+
+import org.mtr.mapping.holder.Matrix4f;
+
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+public final class VertexAttributeState {
+
+	public final Integer color;
+	public final Integer lightmapUV;
+	public final Matrix4f matrix4f;
+
+	public VertexAttributeState(int color, int lightmapUV, Matrix4f matrix4f) {
+		this.color = color;
+		this.lightmapUV = lightmapUV;
+		this.matrix4f = matrix4f;
+	}
+
+	public VertexAttributeState(@Nullable Integer color, @Nullable Integer lightmapUV) {
+		this.color = color;
+		this.lightmapUV = lightmapUV;
+		matrix4f = null;
+	}
+
+	public void apply() {
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+		if (!(object instanceof VertexAttributeState)) {
+			return false;
+		}
+		final VertexAttributeState vertexAttributeState = (VertexAttributeState) object;
+		return Objects.equals(color, vertexAttributeState.color) && Objects.equals(lightmapUV, vertexAttributeState.lightmapUV) && Objects.equals(matrix4f, vertexAttributeState.matrix4f);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(color, lightmapUV, matrix4f);
+	}
+}

--- a/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/render/vertex/VertexAttributeType.java
+++ b/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/render/vertex/VertexAttributeType.java
@@ -1,0 +1,28 @@
+package org.mtr.mapping.render.vertex;
+
+public enum VertexAttributeType {
+	POSITION(0, 12),
+	COLOR(1, 4),
+	UV_TEXTURE(2, 8),
+	UV_OVERLAY(3, 4),
+	UV_LIGHTMAP(4, 4),
+	NORMAL(5, 3),
+	MATRIX_MODEL(6, 64);
+
+	public final int location;
+	public final int byteSize;
+
+	VertexAttributeType(int location, int byteSize) {
+		this.location = location;
+		this.byteSize = byteSize;
+	}
+
+	public void toggleAttributeArray(boolean enable) {
+	}
+
+	public void setupAttributePointer(int stride, int pointer) {
+	}
+
+	public void setAttributeDivisor(int divisor) {
+	}
+}

--- a/fabric/1.17.1-mapping/src/main/java/org/mtr/mapping/mapper/GraphicsHolder.java
+++ b/fabric/1.17.1-mapping/src/main/java/org/mtr/mapping/mapper/GraphicsHolder.java
@@ -126,6 +126,11 @@ public final class GraphicsHolder extends DummyClass {
 	}
 
 	@MappedMethod
+	public org.mtr.mapping.holder.Matrix4f copyPositionMatrix() {
+		return matrixStack == null ? new org.mtr.mapping.holder.Matrix4f() : new org.mtr.mapping.holder.Matrix4f(matrixStack.peek().getModel());
+	}
+
+	@MappedMethod
 	public void drawText(MutableText mutableText, int x, int y, int color, boolean shadow, int light) {
 		if (matrixStack != null) {
 			final VertexConsumerProvider.Immediate immediate = VertexConsumerProvider.immediate(net.minecraft.client.render.Tessellator.getInstance().getBuffer());

--- a/fabric/1.17.1-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/fabric/1.17.1-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -119,13 +119,10 @@ public final class OptimizedModel extends DummyClass {
 		private final RawModel rawModel = new RawModel();
 
 		private ObjModel(
-				List<RawMesh> rawMeshes, boolean flipTextureV,
+				List<RawMesh> rawMeshes,
 				float minX, float minY, float minZ,
 				float maxX, float maxY, float maxZ
 		) {
-			if (flipTextureV) {
-				rawMeshes.forEach(rawMesh -> rawMesh.applyUVMirror(false, true));
-			}
 			this.minX = minX;
 			this.minY = minY;
 			this.minZ = minZ;
@@ -143,9 +140,9 @@ public final class OptimizedModel extends DummyClass {
 
 			final Map<String, ObjModel> objModels = new HashMap<>();
 			ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel).forEach((key, rawMeshes) -> {
+				prepareRawMeshes(rawMeshes, flipTextureV);
 				final float[] bounds = {Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE};
 				rawMeshes.forEach(rawMesh -> {
-					rawMesh.applyRotation(new Vector3f(1, 0, 0), 180);
 					rawMesh.vertices.forEach(vertex -> {
 						final float x = vertex.position.getX();
 						final float y = vertex.position.getY();
@@ -158,10 +155,21 @@ public final class OptimizedModel extends DummyClass {
 						bounds[5] = Math.max(bounds[5], z);
 					});
 				});
-				objModels.put(key, new ObjModel(rawMeshes, flipTextureV, bounds[0], bounds[1], bounds[2], bounds[3], bounds[4], bounds[5]));
+				objModels.put(key, new ObjModel(rawMeshes, bounds[0], bounds[1], bounds[2], bounds[3], bounds[4], bounds[5]));
 			});
 
 			return objModels;
+		}
+
+		@MappedMethod
+		public static Map<String, List<RawMesh>> loadRawModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, @Nullable Identifier atlasIndex, boolean splitModel, boolean flipTextureV) {
+			if (atlasIndex != null) {
+				ATLAS_MANAGER.load(atlasIndex);
+			}
+
+			final Map<String, List<RawMesh>> rawModels = ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel);
+			rawModels.values().forEach(rawMeshes -> prepareRawMeshes(rawMeshes, flipTextureV));
+			return rawModels;
 		}
 
 		@MappedMethod
@@ -229,6 +237,15 @@ public final class OptimizedModel extends DummyClass {
 		public float getMaxZ() {
 			return maxZ;
 		}
+		private static void prepareRawMeshes(List<RawMesh> rawMeshes, boolean flipTextureV) {
+			rawMeshes.forEach(rawMesh -> {
+				rawMesh.applyRotation(new Vector3f(1, 0, 0), 180);
+				if (flipTextureV) {
+					rawMesh.applyUVMirror(false, true);
+				}
+			});
+		}
+
 	}
 
 	public enum ShaderType {

--- a/fabric/1.17.1-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedRenderer.java
+++ b/fabric/1.17.1-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedRenderer.java
@@ -10,20 +10,49 @@ import org.mtr.mapping.render.tool.Utilities;
 import org.mtr.mapping.render.vertex.VertexAttributeState;
 import org.mtr.mapping.tool.DummyClass;
 
+import java.util.function.Supplier;
+
 public final class OptimizedRenderer extends DummyClass {
 
 	private final BatchManager batchManager = new BatchManager();
 	private final ShaderManager shaderManager = new ShaderManager();
+	private int protectedDepth;
+	private int reloadDepth;
 
 	@MappedMethod
 	public void beginReload() {
-		shaderManager.reloadShaders();
-		GlStateTracker.capture();
+		if (reloadDepth++ == 0) {
+			shaderManager.reloadShaders();
+		}
+		beginProtectedState();
 	}
 
 	@MappedMethod
 	public void finishReload() {
-		GlStateTracker.restore();
+		if (reloadDepth > 0) {
+			reloadDepth--;
+			finishProtectedState();
+		}
+	}
+
+	@MappedMethod
+	public void runWithProtectedState(Runnable runnable) {
+		beginProtectedState();
+		try {
+			runnable.run();
+		} finally {
+			finishProtectedState();
+		}
+	}
+
+	@MappedMethod
+	public <T> T runWithProtectedState(Supplier<T> supplier) {
+		beginProtectedState();
+		try {
+			return supplier.get();
+		} finally {
+			finishProtectedState();
+		}
 	}
 
 	@MappedMethod
@@ -36,9 +65,7 @@ public final class OptimizedRenderer extends DummyClass {
 	@MappedMethod
 	public void render(boolean renderTranslucent) {
 		if (shaderManager.isReady()) {
-			GlStateTracker.capture();
-			batchManager.drawAll(shaderManager, renderTranslucent);
-			GlStateTracker.restore();
+			runWithProtectedState(() -> batchManager.drawAll(shaderManager, renderTranslucent));
 		}
 	}
 
@@ -53,5 +80,17 @@ public final class OptimizedRenderer extends DummyClass {
 	@MappedMethod
 	public static boolean hasOptimizedRendering() {
 		return true;
+	}
+
+	private void beginProtectedState() {
+		if (protectedDepth++ == 0) {
+			GlStateTracker.capture();
+		}
+	}
+
+	private void finishProtectedState() {
+		if (protectedDepth > 0 && --protectedDepth == 0) {
+			GlStateTracker.restore();
+		}
 	}
 }

--- a/fabric/1.17.1-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
+++ b/fabric/1.17.1-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
@@ -108,7 +108,9 @@ public final class ObjModelLoader {
 					mesh.faces.add(new Face(new int[]{face.getVertexIndex(0), face.getVertexIndex(1), face.getVertexIndex(2)}));
 				}
 
-				atlasManager.applyToMesh(mesh);
+				if (atlasManager != null) {
+					atlasManager.applyToMesh(mesh);
+				}
 				mesh.validateVertexIndex();
 				rawMeshes.add(mesh);
 			}

--- a/fabric/1.17.1-mapping/src/main/java/org/mtr/mapping/render/object/InstancedDrawHelper.java
+++ b/fabric/1.17.1-mapping/src/main/java/org/mtr/mapping/render/object/InstancedDrawHelper.java
@@ -1,0 +1,71 @@
+package org.mtr.mapping.render.object;
+
+import org.lwjgl.opengl.ARBInstancedArrays;
+import org.lwjgl.opengl.GL;
+import org.lwjgl.opengl.GL33;
+import org.mtr.mapping.render.vertex.VertexAttributeMapping;
+import org.mtr.mapping.render.vertex.VertexAttributeType;
+
+import java.nio.ByteBuffer;
+
+public final class InstancedDrawHelper {
+
+	public static boolean setupInstanceAttributes(VertexArray vertexArray, VertexBuffer instanceBuffer, VertexAttributeMapping mapping, VertexAttributeType... vertexAttributeTypes) {
+		vertexArray.bind();
+		instanceBuffer.bind(GL33.GL_ARRAY_BUFFER);
+		boolean supported = true;
+		for (final VertexAttributeType vertexAttributeType : vertexAttributeTypes) {
+			supported &= setupInstanceAttribute(mapping, vertexAttributeType);
+		}
+		VertexArray.unbind();
+		return supported;
+	}
+
+	public static void setupInstanceAttributePointers(VertexBuffer instanceBuffer, VertexAttributeMapping mapping, int instanceOffsetBytes, VertexAttributeType... vertexAttributeTypes) {
+		instanceBuffer.bind(GL33.GL_ARRAY_BUFFER);
+		for (final VertexAttributeType vertexAttributeType : vertexAttributeTypes) {
+			vertexAttributeType.setupAttributePointer(mapping.strideInstance, instanceOffsetBytes + mapping.pointers.get(vertexAttributeType));
+		}
+	}
+
+	public static void uploadInstances(VertexBuffer instanceBuffer, ByteBuffer byteBuffer, int size) {
+		instanceBuffer.bind(GL33.GL_ARRAY_BUFFER);
+		instanceBuffer.upload(byteBuffer, size, VertexBuffer.USAGE_STREAM_DRAW);
+	}
+
+	public static void drawElementsInstanced(VertexArray vertexArray, int instanceCount) {
+		GL33.glDrawElementsInstanced(GL33.GL_TRIANGLES, vertexArray.indexBuffer.getVertexCount(), vertexArray.indexBuffer.indexType, 0, instanceCount);
+	}
+
+	private static boolean setupInstanceAttribute(VertexAttributeMapping mapping, VertexAttributeType vertexAttributeType) {
+		vertexAttributeType.toggleAttributeArray(true);
+		vertexAttributeType.setupAttributePointer(mapping.strideInstance, mapping.pointers.get(vertexAttributeType));
+		return applyInstanceAttributeDivisor(vertexAttributeType);
+	}
+
+	private static boolean applyInstanceAttributeDivisor(VertexAttributeType vertexAttributeType) {
+		boolean supported = true;
+		for (int i = 0; i < vertexAttributeType.span; i++) {
+			supported &= applyInstanceAttributeDivisor(vertexAttributeType.location + i);
+		}
+		return supported;
+	}
+
+	private static boolean applyInstanceAttributeDivisor(int location) {
+		try {
+			final org.lwjgl.opengl.GLCapabilities capabilities = GL.getCapabilities();
+			if (capabilities.OpenGL33) {
+				GL33.glVertexAttribDivisor(location, 1);
+				return true;
+			} else if (capabilities.GL_ARB_instanced_arrays) {
+				ARBInstancedArrays.glVertexAttribDivisorARB(location, 1);
+				return true;
+			}
+		} catch (IllegalStateException ignored) {
+		}
+		return false;
+	}
+
+	private InstancedDrawHelper() {
+	}
+}

--- a/fabric/1.17.1-mapping/src/main/java/org/mtr/mapping/render/shader/PatchingResourceProvider.java
+++ b/fabric/1.17.1-mapping/src/main/java/org/mtr/mapping/render/shader/PatchingResourceProvider.java
@@ -40,9 +40,11 @@ public final class PatchingResourceProvider implements ResourceFactory {
 				inputStream.close();
 				dataObject.addProperty("vertex", dataObject.get("vertex").getAsString() + "_modelmat");
 				final JsonArray attributeArray = dataObject.get("attributes").getAsJsonArray();
-				for (int i = 0; i < 6 - attributeArray.size(); i++) {
-					attributeArray.add("Dummy" + i);
-				}
+				int dummyIndex = 0;
+					while (attributeArray.size() < 6) {
+						attributeArray.add("Dummy" + dummyIndex);
+						dummyIndex++;
+					}
 				attributeArray.add("ModelMat");
 				returningContent = dataObject.toString();
 			} else if (newIdentifier.getPath().endsWith(".vsh")) {

--- a/fabric/1.17.1-mapping/src/main/java/org/mtr/mapping/render/tool/GlStateTracker.java
+++ b/fabric/1.17.1-mapping/src/main/java/org/mtr/mapping/render/tool/GlStateTracker.java
@@ -12,9 +12,24 @@ public final class GlStateTracker {
 	private static boolean supportVertexAttributeDivisor;
 	private static boolean isGl4ES = false;
 
+	private static final int SHADER_TEXTURE_COUNT = 8;
+
 	private static int vertArrayBinding;
 	private static int arrayBufBinding;
 	private static int elementBufBinding;
+	private static int activeTexture;
+	private static final int[] shaderTextures = new int[SHADER_TEXTURE_COUNT];
+	private static boolean blendEnabled;
+	private static boolean depthTestEnabled;
+	private static boolean cullEnabled;
+	private static boolean depthMask;
+	private static int depthFunc;
+	private static int blendSrcRgb;
+	private static int blendDstRgb;
+	private static int blendSrcAlpha;
+	private static int blendDstAlpha;
+	private static int blendEquationRgb;
+	private static int blendEquationAlpha;
 	private static Shader currentShaderProgram;
 	private static boolean isStateProtected;
 
@@ -31,6 +46,21 @@ public final class GlStateTracker {
 		vertArrayBinding = GL33.glGetInteger(GL33.GL_VERTEX_ARRAY_BINDING);
 		arrayBufBinding = GL33.glGetInteger(GL33.GL_ARRAY_BUFFER_BINDING);
 		elementBufBinding = GL33.glGetInteger(GL33.GL_ELEMENT_ARRAY_BUFFER_BINDING);
+		activeTexture = GL33.glGetInteger(GL33.GL_ACTIVE_TEXTURE);
+		for (int i = 0; i < SHADER_TEXTURE_COUNT; i++) {
+			shaderTextures[i] = RenderSystem.getShaderTexture(i);
+		}
+		blendEnabled = GL33.glIsEnabled(GL33.GL_BLEND);
+		depthTestEnabled = GL33.glIsEnabled(GL33.GL_DEPTH_TEST);
+		cullEnabled = GL33.glIsEnabled(GL33.GL_CULL_FACE);
+		depthMask = GL33.glGetBoolean(GL33.GL_DEPTH_WRITEMASK);
+		depthFunc = GL33.glGetInteger(GL33.GL_DEPTH_FUNC);
+		blendSrcRgb = GL33.glGetInteger(GL33.GL_BLEND_SRC_RGB);
+		blendDstRgb = GL33.glGetInteger(GL33.GL_BLEND_DST_RGB);
+		blendSrcAlpha = GL33.glGetInteger(GL33.GL_BLEND_SRC_ALPHA);
+		blendDstAlpha = GL33.glGetInteger(GL33.GL_BLEND_DST_ALPHA);
+		blendEquationRgb = GL33.glGetInteger(GL33.GL_BLEND_EQUATION_RGB);
+		blendEquationAlpha = GL33.glGetInteger(GL33.GL_BLEND_EQUATION_ALPHA);
 		currentShaderProgram = RenderSystem.getShader();
 		isStateProtected = true;
 	}
@@ -46,12 +76,44 @@ public final class GlStateTracker {
 		GL33.glBindBuffer(GL33.GL_ELEMENT_ARRAY_BUFFER, elementBufBinding);
 
 		RenderSystem.setShader(() -> currentShaderProgram);
+		for (int i = 0; i < SHADER_TEXTURE_COUNT; i++) {
+			RenderSystem.setShaderTexture(i, shaderTextures[i]);
+		}
+		GL33.glActiveTexture(activeTexture);
 
-		// Obtain original state from RenderSystem?
-		RenderSystem.enableCull();
-		RenderSystem.depthMask(true);
+		setBlend(blendEnabled);
+		setDepthTest(depthTestEnabled);
+		setCull(cullEnabled);
+		RenderSystem.depthMask(depthMask);
+		RenderSystem.depthFunc(depthFunc);
+		GL33.glBlendFuncSeparate(blendSrcRgb, blendDstRgb, blendSrcAlpha, blendDstAlpha);
+		GL33.glBlendEquationSeparate(blendEquationRgb, blendEquationAlpha);
 
 		isStateProtected = false;
+	}
+
+	private static void setBlend(boolean enabled) {
+		if (enabled) {
+			RenderSystem.enableBlend();
+		} else {
+			RenderSystem.disableBlend();
+		}
+	}
+
+	private static void setDepthTest(boolean enabled) {
+		if (enabled) {
+			RenderSystem.enableDepthTest();
+		} else {
+			RenderSystem.disableDepthTest();
+		}
+	}
+
+	private static void setCull(boolean enabled) {
+		if (enabled) {
+			RenderSystem.enableCull();
+		} else {
+			RenderSystem.disableCull();
+		}
 	}
 
 	public static void assertProtected() {

--- a/fabric/1.18.2-mapping/src/main/java/org/mtr/mapping/mapper/GraphicsHolder.java
+++ b/fabric/1.18.2-mapping/src/main/java/org/mtr/mapping/mapper/GraphicsHolder.java
@@ -126,6 +126,11 @@ public final class GraphicsHolder extends DummyClass {
 	}
 
 	@MappedMethod
+	public org.mtr.mapping.holder.Matrix4f copyPositionMatrix() {
+		return matrixStack == null ? new org.mtr.mapping.holder.Matrix4f() : new org.mtr.mapping.holder.Matrix4f(matrixStack.peek().getPositionMatrix());
+	}
+
+	@MappedMethod
 	public void drawText(MutableText mutableText, int x, int y, int color, boolean shadow, int light) {
 		if (matrixStack != null) {
 			final VertexConsumerProvider.Immediate immediate = VertexConsumerProvider.immediate(net.minecraft.client.render.Tessellator.getInstance().getBuffer());

--- a/fabric/1.18.2-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/fabric/1.18.2-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -119,13 +119,10 @@ public final class OptimizedModel extends DummyClass {
 		private final RawModel rawModel = new RawModel();
 
 		private ObjModel(
-				List<RawMesh> rawMeshes, boolean flipTextureV,
+				List<RawMesh> rawMeshes,
 				float minX, float minY, float minZ,
 				float maxX, float maxY, float maxZ
 		) {
-			if (flipTextureV) {
-				rawMeshes.forEach(rawMesh -> rawMesh.applyUVMirror(false, true));
-			}
 			this.minX = minX;
 			this.minY = minY;
 			this.minZ = minZ;
@@ -143,9 +140,9 @@ public final class OptimizedModel extends DummyClass {
 
 			final Map<String, ObjModel> objModels = new HashMap<>();
 			ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel).forEach((key, rawMeshes) -> {
+				prepareRawMeshes(rawMeshes, flipTextureV);
 				final float[] bounds = {Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE};
 				rawMeshes.forEach(rawMesh -> {
-					rawMesh.applyRotation(new Vector3f(1, 0, 0), 180);
 					rawMesh.vertices.forEach(vertex -> {
 						final float x = vertex.position.getX();
 						final float y = vertex.position.getY();
@@ -158,10 +155,21 @@ public final class OptimizedModel extends DummyClass {
 						bounds[5] = Math.max(bounds[5], z);
 					});
 				});
-				objModels.put(key, new ObjModel(rawMeshes, flipTextureV, bounds[0], bounds[1], bounds[2], bounds[3], bounds[4], bounds[5]));
+				objModels.put(key, new ObjModel(rawMeshes, bounds[0], bounds[1], bounds[2], bounds[3], bounds[4], bounds[5]));
 			});
 
 			return objModels;
+		}
+
+		@MappedMethod
+		public static Map<String, List<RawMesh>> loadRawModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, @Nullable Identifier atlasIndex, boolean splitModel, boolean flipTextureV) {
+			if (atlasIndex != null) {
+				ATLAS_MANAGER.load(atlasIndex);
+			}
+
+			final Map<String, List<RawMesh>> rawModels = ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel);
+			rawModels.values().forEach(rawMeshes -> prepareRawMeshes(rawMeshes, flipTextureV));
+			return rawModels;
 		}
 
 		@MappedMethod
@@ -229,6 +237,15 @@ public final class OptimizedModel extends DummyClass {
 		public float getMaxZ() {
 			return maxZ;
 		}
+		private static void prepareRawMeshes(List<RawMesh> rawMeshes, boolean flipTextureV) {
+			rawMeshes.forEach(rawMesh -> {
+				rawMesh.applyRotation(new Vector3f(1, 0, 0), 180);
+				if (flipTextureV) {
+					rawMesh.applyUVMirror(false, true);
+				}
+			});
+		}
+
 	}
 
 	public enum ShaderType {

--- a/fabric/1.18.2-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedRenderer.java
+++ b/fabric/1.18.2-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedRenderer.java
@@ -10,20 +10,49 @@ import org.mtr.mapping.render.tool.Utilities;
 import org.mtr.mapping.render.vertex.VertexAttributeState;
 import org.mtr.mapping.tool.DummyClass;
 
+import java.util.function.Supplier;
+
 public final class OptimizedRenderer extends DummyClass {
 
 	private final BatchManager batchManager = new BatchManager();
 	private final ShaderManager shaderManager = new ShaderManager();
+	private int protectedDepth;
+	private int reloadDepth;
 
 	@MappedMethod
 	public void beginReload() {
-		shaderManager.reloadShaders();
-		GlStateTracker.capture();
+		if (reloadDepth++ == 0) {
+			shaderManager.reloadShaders();
+		}
+		beginProtectedState();
 	}
 
 	@MappedMethod
 	public void finishReload() {
-		GlStateTracker.restore();
+		if (reloadDepth > 0) {
+			reloadDepth--;
+			finishProtectedState();
+		}
+	}
+
+	@MappedMethod
+	public void runWithProtectedState(Runnable runnable) {
+		beginProtectedState();
+		try {
+			runnable.run();
+		} finally {
+			finishProtectedState();
+		}
+	}
+
+	@MappedMethod
+	public <T> T runWithProtectedState(Supplier<T> supplier) {
+		beginProtectedState();
+		try {
+			return supplier.get();
+		} finally {
+			finishProtectedState();
+		}
 	}
 
 	@MappedMethod
@@ -36,9 +65,7 @@ public final class OptimizedRenderer extends DummyClass {
 	@MappedMethod
 	public void render(boolean renderTranslucent) {
 		if (shaderManager.isReady()) {
-			GlStateTracker.capture();
-			batchManager.drawAll(shaderManager, renderTranslucent);
-			GlStateTracker.restore();
+			runWithProtectedState(() -> batchManager.drawAll(shaderManager, renderTranslucent));
 		}
 	}
 
@@ -53,5 +80,17 @@ public final class OptimizedRenderer extends DummyClass {
 	@MappedMethod
 	public static boolean hasOptimizedRendering() {
 		return true;
+	}
+
+	private void beginProtectedState() {
+		if (protectedDepth++ == 0) {
+			GlStateTracker.capture();
+		}
+	}
+
+	private void finishProtectedState() {
+		if (protectedDepth > 0 && --protectedDepth == 0) {
+			GlStateTracker.restore();
+		}
 	}
 }

--- a/fabric/1.18.2-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
+++ b/fabric/1.18.2-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
@@ -108,7 +108,9 @@ public final class ObjModelLoader {
 					mesh.faces.add(new Face(new int[]{face.getVertexIndex(0), face.getVertexIndex(1), face.getVertexIndex(2)}));
 				}
 
-				atlasManager.applyToMesh(mesh);
+				if (atlasManager != null) {
+					atlasManager.applyToMesh(mesh);
+				}
 				mesh.validateVertexIndex();
 				rawMeshes.add(mesh);
 			}

--- a/fabric/1.18.2-mapping/src/main/java/org/mtr/mapping/render/object/InstancedDrawHelper.java
+++ b/fabric/1.18.2-mapping/src/main/java/org/mtr/mapping/render/object/InstancedDrawHelper.java
@@ -1,0 +1,71 @@
+package org.mtr.mapping.render.object;
+
+import org.lwjgl.opengl.ARBInstancedArrays;
+import org.lwjgl.opengl.GL;
+import org.lwjgl.opengl.GL33;
+import org.mtr.mapping.render.vertex.VertexAttributeMapping;
+import org.mtr.mapping.render.vertex.VertexAttributeType;
+
+import java.nio.ByteBuffer;
+
+public final class InstancedDrawHelper {
+
+	public static boolean setupInstanceAttributes(VertexArray vertexArray, VertexBuffer instanceBuffer, VertexAttributeMapping mapping, VertexAttributeType... vertexAttributeTypes) {
+		vertexArray.bind();
+		instanceBuffer.bind(GL33.GL_ARRAY_BUFFER);
+		boolean supported = true;
+		for (final VertexAttributeType vertexAttributeType : vertexAttributeTypes) {
+			supported &= setupInstanceAttribute(mapping, vertexAttributeType);
+		}
+		VertexArray.unbind();
+		return supported;
+	}
+
+	public static void setupInstanceAttributePointers(VertexBuffer instanceBuffer, VertexAttributeMapping mapping, int instanceOffsetBytes, VertexAttributeType... vertexAttributeTypes) {
+		instanceBuffer.bind(GL33.GL_ARRAY_BUFFER);
+		for (final VertexAttributeType vertexAttributeType : vertexAttributeTypes) {
+			vertexAttributeType.setupAttributePointer(mapping.strideInstance, instanceOffsetBytes + mapping.pointers.get(vertexAttributeType));
+		}
+	}
+
+	public static void uploadInstances(VertexBuffer instanceBuffer, ByteBuffer byteBuffer, int size) {
+		instanceBuffer.bind(GL33.GL_ARRAY_BUFFER);
+		instanceBuffer.upload(byteBuffer, size, VertexBuffer.USAGE_STREAM_DRAW);
+	}
+
+	public static void drawElementsInstanced(VertexArray vertexArray, int instanceCount) {
+		GL33.glDrawElementsInstanced(GL33.GL_TRIANGLES, vertexArray.indexBuffer.getVertexCount(), vertexArray.indexBuffer.indexType, 0, instanceCount);
+	}
+
+	private static boolean setupInstanceAttribute(VertexAttributeMapping mapping, VertexAttributeType vertexAttributeType) {
+		vertexAttributeType.toggleAttributeArray(true);
+		vertexAttributeType.setupAttributePointer(mapping.strideInstance, mapping.pointers.get(vertexAttributeType));
+		return applyInstanceAttributeDivisor(vertexAttributeType);
+	}
+
+	private static boolean applyInstanceAttributeDivisor(VertexAttributeType vertexAttributeType) {
+		boolean supported = true;
+		for (int i = 0; i < vertexAttributeType.span; i++) {
+			supported &= applyInstanceAttributeDivisor(vertexAttributeType.location + i);
+		}
+		return supported;
+	}
+
+	private static boolean applyInstanceAttributeDivisor(int location) {
+		try {
+			final org.lwjgl.opengl.GLCapabilities capabilities = GL.getCapabilities();
+			if (capabilities.OpenGL33) {
+				GL33.glVertexAttribDivisor(location, 1);
+				return true;
+			} else if (capabilities.GL_ARB_instanced_arrays) {
+				ARBInstancedArrays.glVertexAttribDivisorARB(location, 1);
+				return true;
+			}
+		} catch (IllegalStateException ignored) {
+		}
+		return false;
+	}
+
+	private InstancedDrawHelper() {
+	}
+}

--- a/fabric/1.18.2-mapping/src/main/java/org/mtr/mapping/render/shader/PatchingResourceProvider.java
+++ b/fabric/1.18.2-mapping/src/main/java/org/mtr/mapping/render/shader/PatchingResourceProvider.java
@@ -40,9 +40,11 @@ public final class PatchingResourceProvider implements ResourceFactory {
 				inputStream.close();
 				dataObject.addProperty("vertex", dataObject.get("vertex").getAsString() + "_modelmat");
 				final JsonArray attributeArray = dataObject.get("attributes").getAsJsonArray();
-				for (int i = 0; i < 6 - attributeArray.size(); i++) {
-					attributeArray.add("Dummy" + i);
-				}
+				int dummyIndex = 0;
+					while (attributeArray.size() < 6) {
+						attributeArray.add("Dummy" + dummyIndex);
+						dummyIndex++;
+					}
 				attributeArray.add("ModelMat");
 				returningContent = dataObject.toString();
 			} else if (newIdentifier.getPath().endsWith(".vsh")) {

--- a/fabric/1.18.2-mapping/src/main/java/org/mtr/mapping/render/tool/GlStateTracker.java
+++ b/fabric/1.18.2-mapping/src/main/java/org/mtr/mapping/render/tool/GlStateTracker.java
@@ -12,9 +12,24 @@ public final class GlStateTracker {
 	private static boolean supportVertexAttributeDivisor;
 	private static boolean isGl4ES = false;
 
+	private static final int SHADER_TEXTURE_COUNT = 8;
+
 	private static int vertArrayBinding;
 	private static int arrayBufBinding;
 	private static int elementBufBinding;
+	private static int activeTexture;
+	private static final int[] shaderTextures = new int[SHADER_TEXTURE_COUNT];
+	private static boolean blendEnabled;
+	private static boolean depthTestEnabled;
+	private static boolean cullEnabled;
+	private static boolean depthMask;
+	private static int depthFunc;
+	private static int blendSrcRgb;
+	private static int blendDstRgb;
+	private static int blendSrcAlpha;
+	private static int blendDstAlpha;
+	private static int blendEquationRgb;
+	private static int blendEquationAlpha;
 	private static Shader currentShaderProgram;
 	private static boolean isStateProtected;
 
@@ -31,6 +46,21 @@ public final class GlStateTracker {
 		vertArrayBinding = GL33.glGetInteger(GL33.GL_VERTEX_ARRAY_BINDING);
 		arrayBufBinding = GL33.glGetInteger(GL33.GL_ARRAY_BUFFER_BINDING);
 		elementBufBinding = GL33.glGetInteger(GL33.GL_ELEMENT_ARRAY_BUFFER_BINDING);
+		activeTexture = GL33.glGetInteger(GL33.GL_ACTIVE_TEXTURE);
+		for (int i = 0; i < SHADER_TEXTURE_COUNT; i++) {
+			shaderTextures[i] = RenderSystem.getShaderTexture(i);
+		}
+		blendEnabled = GL33.glIsEnabled(GL33.GL_BLEND);
+		depthTestEnabled = GL33.glIsEnabled(GL33.GL_DEPTH_TEST);
+		cullEnabled = GL33.glIsEnabled(GL33.GL_CULL_FACE);
+		depthMask = GL33.glGetBoolean(GL33.GL_DEPTH_WRITEMASK);
+		depthFunc = GL33.glGetInteger(GL33.GL_DEPTH_FUNC);
+		blendSrcRgb = GL33.glGetInteger(GL33.GL_BLEND_SRC_RGB);
+		blendDstRgb = GL33.glGetInteger(GL33.GL_BLEND_DST_RGB);
+		blendSrcAlpha = GL33.glGetInteger(GL33.GL_BLEND_SRC_ALPHA);
+		blendDstAlpha = GL33.glGetInteger(GL33.GL_BLEND_DST_ALPHA);
+		blendEquationRgb = GL33.glGetInteger(GL33.GL_BLEND_EQUATION_RGB);
+		blendEquationAlpha = GL33.glGetInteger(GL33.GL_BLEND_EQUATION_ALPHA);
 		currentShaderProgram = RenderSystem.getShader();
 		isStateProtected = true;
 	}
@@ -46,12 +76,44 @@ public final class GlStateTracker {
 		GL33.glBindBuffer(GL33.GL_ELEMENT_ARRAY_BUFFER, elementBufBinding);
 
 		RenderSystem.setShader(() -> currentShaderProgram);
+		for (int i = 0; i < SHADER_TEXTURE_COUNT; i++) {
+			RenderSystem.setShaderTexture(i, shaderTextures[i]);
+		}
+		GL33.glActiveTexture(activeTexture);
 
-		// Obtain original state from RenderSystem?
-		RenderSystem.enableCull();
-		RenderSystem.depthMask(true);
+		setBlend(blendEnabled);
+		setDepthTest(depthTestEnabled);
+		setCull(cullEnabled);
+		RenderSystem.depthMask(depthMask);
+		RenderSystem.depthFunc(depthFunc);
+		GL33.glBlendFuncSeparate(blendSrcRgb, blendDstRgb, blendSrcAlpha, blendDstAlpha);
+		GL33.glBlendEquationSeparate(blendEquationRgb, blendEquationAlpha);
 
 		isStateProtected = false;
+	}
+
+	private static void setBlend(boolean enabled) {
+		if (enabled) {
+			RenderSystem.enableBlend();
+		} else {
+			RenderSystem.disableBlend();
+		}
+	}
+
+	private static void setDepthTest(boolean enabled) {
+		if (enabled) {
+			RenderSystem.enableDepthTest();
+		} else {
+			RenderSystem.disableDepthTest();
+		}
+	}
+
+	private static void setCull(boolean enabled) {
+		if (enabled) {
+			RenderSystem.enableCull();
+		} else {
+			RenderSystem.disableCull();
+		}
 	}
 
 	public static void assertProtected() {

--- a/fabric/1.19.2-mapping/src/main/java/org/mtr/mapping/mapper/GraphicsHolder.java
+++ b/fabric/1.19.2-mapping/src/main/java/org/mtr/mapping/mapper/GraphicsHolder.java
@@ -126,6 +126,11 @@ public final class GraphicsHolder extends DummyClass {
 	}
 
 	@MappedMethod
+	public org.mtr.mapping.holder.Matrix4f copyPositionMatrix() {
+		return matrixStack == null ? new org.mtr.mapping.holder.Matrix4f() : new org.mtr.mapping.holder.Matrix4f(matrixStack.peek().getPositionMatrix());
+	}
+
+	@MappedMethod
 	public void drawText(MutableText mutableText, int x, int y, int color, boolean shadow, int light) {
 		if (matrixStack != null) {
 			final VertexConsumerProvider.Immediate immediate = VertexConsumerProvider.immediate(net.minecraft.client.render.Tessellator.getInstance().getBuffer());

--- a/fabric/1.19.2-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/fabric/1.19.2-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -119,13 +119,10 @@ public final class OptimizedModel extends DummyClass {
 		private final RawModel rawModel = new RawModel();
 
 		private ObjModel(
-				List<RawMesh> rawMeshes, boolean flipTextureV,
+				List<RawMesh> rawMeshes,
 				float minX, float minY, float minZ,
 				float maxX, float maxY, float maxZ
 		) {
-			if (flipTextureV) {
-				rawMeshes.forEach(rawMesh -> rawMesh.applyUVMirror(false, true));
-			}
 			this.minX = minX;
 			this.minY = minY;
 			this.minZ = minZ;
@@ -143,9 +140,9 @@ public final class OptimizedModel extends DummyClass {
 
 			final Map<String, ObjModel> objModels = new HashMap<>();
 			ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel).forEach((key, rawMeshes) -> {
+				prepareRawMeshes(rawMeshes, flipTextureV);
 				final float[] bounds = {Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE};
 				rawMeshes.forEach(rawMesh -> {
-					rawMesh.applyRotation(new Vector3f(1, 0, 0), 180);
 					rawMesh.vertices.forEach(vertex -> {
 						final float x = vertex.position.getX();
 						final float y = vertex.position.getY();
@@ -158,10 +155,21 @@ public final class OptimizedModel extends DummyClass {
 						bounds[5] = Math.max(bounds[5], z);
 					});
 				});
-				objModels.put(key, new ObjModel(rawMeshes, flipTextureV, bounds[0], bounds[1], bounds[2], bounds[3], bounds[4], bounds[5]));
+				objModels.put(key, new ObjModel(rawMeshes, bounds[0], bounds[1], bounds[2], bounds[3], bounds[4], bounds[5]));
 			});
 
 			return objModels;
+		}
+
+		@MappedMethod
+		public static Map<String, List<RawMesh>> loadRawModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, @Nullable Identifier atlasIndex, boolean splitModel, boolean flipTextureV) {
+			if (atlasIndex != null) {
+				ATLAS_MANAGER.load(atlasIndex);
+			}
+
+			final Map<String, List<RawMesh>> rawModels = ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel);
+			rawModels.values().forEach(rawMeshes -> prepareRawMeshes(rawMeshes, flipTextureV));
+			return rawModels;
 		}
 
 		@MappedMethod
@@ -229,6 +237,15 @@ public final class OptimizedModel extends DummyClass {
 		public float getMaxZ() {
 			return maxZ;
 		}
+		private static void prepareRawMeshes(List<RawMesh> rawMeshes, boolean flipTextureV) {
+			rawMeshes.forEach(rawMesh -> {
+				rawMesh.applyRotation(new Vector3f(1, 0, 0), 180);
+				if (flipTextureV) {
+					rawMesh.applyUVMirror(false, true);
+				}
+			});
+		}
+
 	}
 
 	public enum ShaderType {

--- a/fabric/1.19.2-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedRenderer.java
+++ b/fabric/1.19.2-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedRenderer.java
@@ -10,20 +10,49 @@ import org.mtr.mapping.render.tool.Utilities;
 import org.mtr.mapping.render.vertex.VertexAttributeState;
 import org.mtr.mapping.tool.DummyClass;
 
+import java.util.function.Supplier;
+
 public final class OptimizedRenderer extends DummyClass {
 
 	private final BatchManager batchManager = new BatchManager();
 	private final ShaderManager shaderManager = new ShaderManager();
+	private int protectedDepth;
+	private int reloadDepth;
 
 	@MappedMethod
 	public void beginReload() {
-		shaderManager.reloadShaders();
-		GlStateTracker.capture();
+		if (reloadDepth++ == 0) {
+			shaderManager.reloadShaders();
+		}
+		beginProtectedState();
 	}
 
 	@MappedMethod
 	public void finishReload() {
-		GlStateTracker.restore();
+		if (reloadDepth > 0) {
+			reloadDepth--;
+			finishProtectedState();
+		}
+	}
+
+	@MappedMethod
+	public void runWithProtectedState(Runnable runnable) {
+		beginProtectedState();
+		try {
+			runnable.run();
+		} finally {
+			finishProtectedState();
+		}
+	}
+
+	@MappedMethod
+	public <T> T runWithProtectedState(Supplier<T> supplier) {
+		beginProtectedState();
+		try {
+			return supplier.get();
+		} finally {
+			finishProtectedState();
+		}
 	}
 
 	@MappedMethod
@@ -36,9 +65,7 @@ public final class OptimizedRenderer extends DummyClass {
 	@MappedMethod
 	public void render(boolean renderTranslucent) {
 		if (shaderManager.isReady()) {
-			GlStateTracker.capture();
-			batchManager.drawAll(shaderManager, renderTranslucent);
-			GlStateTracker.restore();
+			runWithProtectedState(() -> batchManager.drawAll(shaderManager, renderTranslucent));
 		}
 	}
 
@@ -53,5 +80,17 @@ public final class OptimizedRenderer extends DummyClass {
 	@MappedMethod
 	public static boolean hasOptimizedRendering() {
 		return true;
+	}
+
+	private void beginProtectedState() {
+		if (protectedDepth++ == 0) {
+			GlStateTracker.capture();
+		}
+	}
+
+	private void finishProtectedState() {
+		if (protectedDepth > 0 && --protectedDepth == 0) {
+			GlStateTracker.restore();
+		}
 	}
 }

--- a/fabric/1.19.2-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
+++ b/fabric/1.19.2-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
@@ -108,7 +108,9 @@ public final class ObjModelLoader {
 					mesh.faces.add(new Face(new int[]{face.getVertexIndex(0), face.getVertexIndex(1), face.getVertexIndex(2)}));
 				}
 
-				atlasManager.applyToMesh(mesh);
+				if (atlasManager != null) {
+					atlasManager.applyToMesh(mesh);
+				}
 				mesh.validateVertexIndex();
 				rawMeshes.add(mesh);
 			}

--- a/fabric/1.19.2-mapping/src/main/java/org/mtr/mapping/render/object/InstancedDrawHelper.java
+++ b/fabric/1.19.2-mapping/src/main/java/org/mtr/mapping/render/object/InstancedDrawHelper.java
@@ -1,0 +1,71 @@
+package org.mtr.mapping.render.object;
+
+import org.lwjgl.opengl.ARBInstancedArrays;
+import org.lwjgl.opengl.GL;
+import org.lwjgl.opengl.GL33;
+import org.mtr.mapping.render.vertex.VertexAttributeMapping;
+import org.mtr.mapping.render.vertex.VertexAttributeType;
+
+import java.nio.ByteBuffer;
+
+public final class InstancedDrawHelper {
+
+	public static boolean setupInstanceAttributes(VertexArray vertexArray, VertexBuffer instanceBuffer, VertexAttributeMapping mapping, VertexAttributeType... vertexAttributeTypes) {
+		vertexArray.bind();
+		instanceBuffer.bind(GL33.GL_ARRAY_BUFFER);
+		boolean supported = true;
+		for (final VertexAttributeType vertexAttributeType : vertexAttributeTypes) {
+			supported &= setupInstanceAttribute(mapping, vertexAttributeType);
+		}
+		VertexArray.unbind();
+		return supported;
+	}
+
+	public static void setupInstanceAttributePointers(VertexBuffer instanceBuffer, VertexAttributeMapping mapping, int instanceOffsetBytes, VertexAttributeType... vertexAttributeTypes) {
+		instanceBuffer.bind(GL33.GL_ARRAY_BUFFER);
+		for (final VertexAttributeType vertexAttributeType : vertexAttributeTypes) {
+			vertexAttributeType.setupAttributePointer(mapping.strideInstance, instanceOffsetBytes + mapping.pointers.get(vertexAttributeType));
+		}
+	}
+
+	public static void uploadInstances(VertexBuffer instanceBuffer, ByteBuffer byteBuffer, int size) {
+		instanceBuffer.bind(GL33.GL_ARRAY_BUFFER);
+		instanceBuffer.upload(byteBuffer, size, VertexBuffer.USAGE_STREAM_DRAW);
+	}
+
+	public static void drawElementsInstanced(VertexArray vertexArray, int instanceCount) {
+		GL33.glDrawElementsInstanced(GL33.GL_TRIANGLES, vertexArray.indexBuffer.getVertexCount(), vertexArray.indexBuffer.indexType, 0, instanceCount);
+	}
+
+	private static boolean setupInstanceAttribute(VertexAttributeMapping mapping, VertexAttributeType vertexAttributeType) {
+		vertexAttributeType.toggleAttributeArray(true);
+		vertexAttributeType.setupAttributePointer(mapping.strideInstance, mapping.pointers.get(vertexAttributeType));
+		return applyInstanceAttributeDivisor(vertexAttributeType);
+	}
+
+	private static boolean applyInstanceAttributeDivisor(VertexAttributeType vertexAttributeType) {
+		boolean supported = true;
+		for (int i = 0; i < vertexAttributeType.span; i++) {
+			supported &= applyInstanceAttributeDivisor(vertexAttributeType.location + i);
+		}
+		return supported;
+	}
+
+	private static boolean applyInstanceAttributeDivisor(int location) {
+		try {
+			final org.lwjgl.opengl.GLCapabilities capabilities = GL.getCapabilities();
+			if (capabilities.OpenGL33) {
+				GL33.glVertexAttribDivisor(location, 1);
+				return true;
+			} else if (capabilities.GL_ARB_instanced_arrays) {
+				ARBInstancedArrays.glVertexAttribDivisorARB(location, 1);
+				return true;
+			}
+		} catch (IllegalStateException ignored) {
+		}
+		return false;
+	}
+
+	private InstancedDrawHelper() {
+	}
+}

--- a/fabric/1.19.2-mapping/src/main/java/org/mtr/mapping/render/shader/PatchingResourceProvider.java
+++ b/fabric/1.19.2-mapping/src/main/java/org/mtr/mapping/render/shader/PatchingResourceProvider.java
@@ -41,8 +41,10 @@ public final class PatchingResourceProvider implements ResourceFactory {
 					inputStream.close();
 					dataObject.addProperty("vertex", dataObject.get("vertex").getAsString() + "_modelmat");
 					final JsonArray attributeArray = dataObject.get("attributes").getAsJsonArray();
-					for (int i = 0; i < 6 - attributeArray.size(); i++) {
-						attributeArray.add("Dummy" + i);
+					int dummyIndex = 0;
+					while (attributeArray.size() < 6) {
+						attributeArray.add("Dummy" + dummyIndex);
+						dummyIndex++;
 					}
 					attributeArray.add("ModelMat");
 					returningContent = dataObject.toString();

--- a/fabric/1.19.2-mapping/src/main/java/org/mtr/mapping/render/tool/GlStateTracker.java
+++ b/fabric/1.19.2-mapping/src/main/java/org/mtr/mapping/render/tool/GlStateTracker.java
@@ -12,9 +12,24 @@ public final class GlStateTracker {
 	private static boolean supportVertexAttributeDivisor;
 	private static boolean isGl4ES = false;
 
+	private static final int SHADER_TEXTURE_COUNT = 8;
+
 	private static int vertArrayBinding;
 	private static int arrayBufBinding;
 	private static int elementBufBinding;
+	private static int activeTexture;
+	private static final int[] shaderTextures = new int[SHADER_TEXTURE_COUNT];
+	private static boolean blendEnabled;
+	private static boolean depthTestEnabled;
+	private static boolean cullEnabled;
+	private static boolean depthMask;
+	private static int depthFunc;
+	private static int blendSrcRgb;
+	private static int blendDstRgb;
+	private static int blendSrcAlpha;
+	private static int blendDstAlpha;
+	private static int blendEquationRgb;
+	private static int blendEquationAlpha;
 	private static Shader currentShaderProgram;
 	private static boolean isStateProtected;
 
@@ -31,6 +46,21 @@ public final class GlStateTracker {
 		vertArrayBinding = GL33.glGetInteger(GL33.GL_VERTEX_ARRAY_BINDING);
 		arrayBufBinding = GL33.glGetInteger(GL33.GL_ARRAY_BUFFER_BINDING);
 		elementBufBinding = GL33.glGetInteger(GL33.GL_ELEMENT_ARRAY_BUFFER_BINDING);
+		activeTexture = GL33.glGetInteger(GL33.GL_ACTIVE_TEXTURE);
+		for (int i = 0; i < SHADER_TEXTURE_COUNT; i++) {
+			shaderTextures[i] = RenderSystem.getShaderTexture(i);
+		}
+		blendEnabled = GL33.glIsEnabled(GL33.GL_BLEND);
+		depthTestEnabled = GL33.glIsEnabled(GL33.GL_DEPTH_TEST);
+		cullEnabled = GL33.glIsEnabled(GL33.GL_CULL_FACE);
+		depthMask = GL33.glGetBoolean(GL33.GL_DEPTH_WRITEMASK);
+		depthFunc = GL33.glGetInteger(GL33.GL_DEPTH_FUNC);
+		blendSrcRgb = GL33.glGetInteger(GL33.GL_BLEND_SRC_RGB);
+		blendDstRgb = GL33.glGetInteger(GL33.GL_BLEND_DST_RGB);
+		blendSrcAlpha = GL33.glGetInteger(GL33.GL_BLEND_SRC_ALPHA);
+		blendDstAlpha = GL33.glGetInteger(GL33.GL_BLEND_DST_ALPHA);
+		blendEquationRgb = GL33.glGetInteger(GL33.GL_BLEND_EQUATION_RGB);
+		blendEquationAlpha = GL33.glGetInteger(GL33.GL_BLEND_EQUATION_ALPHA);
 		currentShaderProgram = RenderSystem.getShader();
 		isStateProtected = true;
 	}
@@ -46,12 +76,44 @@ public final class GlStateTracker {
 		GL33.glBindBuffer(GL33.GL_ELEMENT_ARRAY_BUFFER, elementBufBinding);
 
 		RenderSystem.setShader(() -> currentShaderProgram);
+		for (int i = 0; i < SHADER_TEXTURE_COUNT; i++) {
+			RenderSystem.setShaderTexture(i, shaderTextures[i]);
+		}
+		GL33.glActiveTexture(activeTexture);
 
-		// Obtain original state from RenderSystem?
-		RenderSystem.enableCull();
-		RenderSystem.depthMask(true);
+		setBlend(blendEnabled);
+		setDepthTest(depthTestEnabled);
+		setCull(cullEnabled);
+		RenderSystem.depthMask(depthMask);
+		RenderSystem.depthFunc(depthFunc);
+		GL33.glBlendFuncSeparate(blendSrcRgb, blendDstRgb, blendSrcAlpha, blendDstAlpha);
+		GL33.glBlendEquationSeparate(blendEquationRgb, blendEquationAlpha);
 
 		isStateProtected = false;
+	}
+
+	private static void setBlend(boolean enabled) {
+		if (enabled) {
+			RenderSystem.enableBlend();
+		} else {
+			RenderSystem.disableBlend();
+		}
+	}
+
+	private static void setDepthTest(boolean enabled) {
+		if (enabled) {
+			RenderSystem.enableDepthTest();
+		} else {
+			RenderSystem.disableDepthTest();
+		}
+	}
+
+	private static void setCull(boolean enabled) {
+		if (enabled) {
+			RenderSystem.enableCull();
+		} else {
+			RenderSystem.disableCull();
+		}
 	}
 
 	public static void assertProtected() {

--- a/fabric/1.19.4-mapping/src/main/java/org/mtr/mapping/mapper/GraphicsHolder.java
+++ b/fabric/1.19.4-mapping/src/main/java/org/mtr/mapping/mapper/GraphicsHolder.java
@@ -127,6 +127,11 @@ public final class GraphicsHolder extends DummyClass {
 	}
 
 	@MappedMethod
+	public org.mtr.mapping.holder.Matrix4f copyPositionMatrix() {
+		return matrixStack == null ? new org.mtr.mapping.holder.Matrix4f() : new org.mtr.mapping.holder.Matrix4f(matrixStack.peek().getPositionMatrix());
+	}
+
+	@MappedMethod
 	public void drawText(MutableText mutableText, int x, int y, int color, boolean shadow, int light) {
 		if (matrixStack != null) {
 			final VertexConsumerProvider.Immediate immediate = VertexConsumerProvider.immediate(net.minecraft.client.render.Tessellator.getInstance().getBuffer());

--- a/fabric/1.19.4-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/fabric/1.19.4-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -119,13 +119,10 @@ public final class OptimizedModel extends DummyClass {
 		private final RawModel rawModel = new RawModel();
 
 		private ObjModel(
-				List<RawMesh> rawMeshes, boolean flipTextureV,
+				List<RawMesh> rawMeshes,
 				float minX, float minY, float minZ,
 				float maxX, float maxY, float maxZ
 		) {
-			if (flipTextureV) {
-				rawMeshes.forEach(rawMesh -> rawMesh.applyUVMirror(false, true));
-			}
 			this.minX = minX;
 			this.minY = minY;
 			this.minZ = minZ;
@@ -143,9 +140,9 @@ public final class OptimizedModel extends DummyClass {
 
 			final Map<String, ObjModel> objModels = new HashMap<>();
 			ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel).forEach((key, rawMeshes) -> {
+				prepareRawMeshes(rawMeshes, flipTextureV);
 				final float[] bounds = {Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE};
 				rawMeshes.forEach(rawMesh -> {
-					rawMesh.applyRotation(new Vector3f(1, 0, 0), 180);
 					rawMesh.vertices.forEach(vertex -> {
 						final float x = vertex.position.getX();
 						final float y = vertex.position.getY();
@@ -158,10 +155,21 @@ public final class OptimizedModel extends DummyClass {
 						bounds[5] = Math.max(bounds[5], z);
 					});
 				});
-				objModels.put(key, new ObjModel(rawMeshes, flipTextureV, bounds[0], bounds[1], bounds[2], bounds[3], bounds[4], bounds[5]));
+				objModels.put(key, new ObjModel(rawMeshes, bounds[0], bounds[1], bounds[2], bounds[3], bounds[4], bounds[5]));
 			});
 
 			return objModels;
+		}
+
+		@MappedMethod
+		public static Map<String, List<RawMesh>> loadRawModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, @Nullable Identifier atlasIndex, boolean splitModel, boolean flipTextureV) {
+			if (atlasIndex != null) {
+				ATLAS_MANAGER.load(atlasIndex);
+			}
+
+			final Map<String, List<RawMesh>> rawModels = ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel);
+			rawModels.values().forEach(rawMeshes -> prepareRawMeshes(rawMeshes, flipTextureV));
+			return rawModels;
 		}
 
 		@MappedMethod
@@ -229,6 +237,15 @@ public final class OptimizedModel extends DummyClass {
 		public float getMaxZ() {
 			return maxZ;
 		}
+		private static void prepareRawMeshes(List<RawMesh> rawMeshes, boolean flipTextureV) {
+			rawMeshes.forEach(rawMesh -> {
+				rawMesh.applyRotation(new Vector3f(1, 0, 0), 180);
+				if (flipTextureV) {
+					rawMesh.applyUVMirror(false, true);
+				}
+			});
+		}
+
 	}
 
 	public enum ShaderType {

--- a/fabric/1.19.4-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedRenderer.java
+++ b/fabric/1.19.4-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedRenderer.java
@@ -10,20 +10,49 @@ import org.mtr.mapping.render.tool.Utilities;
 import org.mtr.mapping.render.vertex.VertexAttributeState;
 import org.mtr.mapping.tool.DummyClass;
 
+import java.util.function.Supplier;
+
 public final class OptimizedRenderer extends DummyClass {
 
 	private final BatchManager batchManager = new BatchManager();
 	private final ShaderManager shaderManager = new ShaderManager();
+	private int protectedDepth;
+	private int reloadDepth;
 
 	@MappedMethod
 	public void beginReload() {
-		shaderManager.reloadShaders();
-		GlStateTracker.capture();
+		if (reloadDepth++ == 0) {
+			shaderManager.reloadShaders();
+		}
+		beginProtectedState();
 	}
 
 	@MappedMethod
 	public void finishReload() {
-		GlStateTracker.restore();
+		if (reloadDepth > 0) {
+			reloadDepth--;
+			finishProtectedState();
+		}
+	}
+
+	@MappedMethod
+	public void runWithProtectedState(Runnable runnable) {
+		beginProtectedState();
+		try {
+			runnable.run();
+		} finally {
+			finishProtectedState();
+		}
+	}
+
+	@MappedMethod
+	public <T> T runWithProtectedState(Supplier<T> supplier) {
+		beginProtectedState();
+		try {
+			return supplier.get();
+		} finally {
+			finishProtectedState();
+		}
 	}
 
 	@MappedMethod
@@ -36,9 +65,7 @@ public final class OptimizedRenderer extends DummyClass {
 	@MappedMethod
 	public void render(boolean renderTranslucent) {
 		if (shaderManager.isReady()) {
-			GlStateTracker.capture();
-			batchManager.drawAll(shaderManager, renderTranslucent);
-			GlStateTracker.restore();
+			runWithProtectedState(() -> batchManager.drawAll(shaderManager, renderTranslucent));
 		}
 	}
 
@@ -53,5 +80,17 @@ public final class OptimizedRenderer extends DummyClass {
 	@MappedMethod
 	public static boolean hasOptimizedRendering() {
 		return true;
+	}
+
+	private void beginProtectedState() {
+		if (protectedDepth++ == 0) {
+			GlStateTracker.capture();
+		}
+	}
+
+	private void finishProtectedState() {
+		if (protectedDepth > 0 && --protectedDepth == 0) {
+			GlStateTracker.restore();
+		}
 	}
 }

--- a/fabric/1.19.4-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
+++ b/fabric/1.19.4-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
@@ -108,7 +108,9 @@ public final class ObjModelLoader {
 					mesh.faces.add(new Face(new int[]{face.getVertexIndex(0), face.getVertexIndex(1), face.getVertexIndex(2)}));
 				}
 
-				atlasManager.applyToMesh(mesh);
+				if (atlasManager != null) {
+					atlasManager.applyToMesh(mesh);
+				}
 				mesh.validateVertexIndex();
 				rawMeshes.add(mesh);
 			}

--- a/fabric/1.19.4-mapping/src/main/java/org/mtr/mapping/render/object/InstancedDrawHelper.java
+++ b/fabric/1.19.4-mapping/src/main/java/org/mtr/mapping/render/object/InstancedDrawHelper.java
@@ -1,0 +1,71 @@
+package org.mtr.mapping.render.object;
+
+import org.lwjgl.opengl.ARBInstancedArrays;
+import org.lwjgl.opengl.GL;
+import org.lwjgl.opengl.GL33;
+import org.mtr.mapping.render.vertex.VertexAttributeMapping;
+import org.mtr.mapping.render.vertex.VertexAttributeType;
+
+import java.nio.ByteBuffer;
+
+public final class InstancedDrawHelper {
+
+	public static boolean setupInstanceAttributes(VertexArray vertexArray, VertexBuffer instanceBuffer, VertexAttributeMapping mapping, VertexAttributeType... vertexAttributeTypes) {
+		vertexArray.bind();
+		instanceBuffer.bind(GL33.GL_ARRAY_BUFFER);
+		boolean supported = true;
+		for (final VertexAttributeType vertexAttributeType : vertexAttributeTypes) {
+			supported &= setupInstanceAttribute(mapping, vertexAttributeType);
+		}
+		VertexArray.unbind();
+		return supported;
+	}
+
+	public static void setupInstanceAttributePointers(VertexBuffer instanceBuffer, VertexAttributeMapping mapping, int instanceOffsetBytes, VertexAttributeType... vertexAttributeTypes) {
+		instanceBuffer.bind(GL33.GL_ARRAY_BUFFER);
+		for (final VertexAttributeType vertexAttributeType : vertexAttributeTypes) {
+			vertexAttributeType.setupAttributePointer(mapping.strideInstance, instanceOffsetBytes + mapping.pointers.get(vertexAttributeType));
+		}
+	}
+
+	public static void uploadInstances(VertexBuffer instanceBuffer, ByteBuffer byteBuffer, int size) {
+		instanceBuffer.bind(GL33.GL_ARRAY_BUFFER);
+		instanceBuffer.upload(byteBuffer, size, VertexBuffer.USAGE_STREAM_DRAW);
+	}
+
+	public static void drawElementsInstanced(VertexArray vertexArray, int instanceCount) {
+		GL33.glDrawElementsInstanced(GL33.GL_TRIANGLES, vertexArray.indexBuffer.getVertexCount(), vertexArray.indexBuffer.indexType, 0, instanceCount);
+	}
+
+	private static boolean setupInstanceAttribute(VertexAttributeMapping mapping, VertexAttributeType vertexAttributeType) {
+		vertexAttributeType.toggleAttributeArray(true);
+		vertexAttributeType.setupAttributePointer(mapping.strideInstance, mapping.pointers.get(vertexAttributeType));
+		return applyInstanceAttributeDivisor(vertexAttributeType);
+	}
+
+	private static boolean applyInstanceAttributeDivisor(VertexAttributeType vertexAttributeType) {
+		boolean supported = true;
+		for (int i = 0; i < vertexAttributeType.span; i++) {
+			supported &= applyInstanceAttributeDivisor(vertexAttributeType.location + i);
+		}
+		return supported;
+	}
+
+	private static boolean applyInstanceAttributeDivisor(int location) {
+		try {
+			final org.lwjgl.opengl.GLCapabilities capabilities = GL.getCapabilities();
+			if (capabilities.OpenGL33) {
+				GL33.glVertexAttribDivisor(location, 1);
+				return true;
+			} else if (capabilities.GL_ARB_instanced_arrays) {
+				ARBInstancedArrays.glVertexAttribDivisorARB(location, 1);
+				return true;
+			}
+		} catch (IllegalStateException ignored) {
+		}
+		return false;
+	}
+
+	private InstancedDrawHelper() {
+	}
+}

--- a/fabric/1.19.4-mapping/src/main/java/org/mtr/mapping/render/shader/PatchingResourceProvider.java
+++ b/fabric/1.19.4-mapping/src/main/java/org/mtr/mapping/render/shader/PatchingResourceProvider.java
@@ -41,8 +41,10 @@ public final class PatchingResourceProvider implements ResourceFactory {
 					inputStream.close();
 					dataObject.addProperty("vertex", dataObject.get("vertex").getAsString() + "_modelmat");
 					final JsonArray attributeArray = dataObject.get("attributes").getAsJsonArray();
-					for (int i = 0; i < 6 - attributeArray.size(); i++) {
-						attributeArray.add("Dummy" + i);
+					int dummyIndex = 0;
+					while (attributeArray.size() < 6) {
+						attributeArray.add("Dummy" + dummyIndex);
+						dummyIndex++;
 					}
 					attributeArray.add("ModelMat");
 					returningContent = dataObject.toString();

--- a/fabric/1.19.4-mapping/src/main/java/org/mtr/mapping/render/tool/GlStateTracker.java
+++ b/fabric/1.19.4-mapping/src/main/java/org/mtr/mapping/render/tool/GlStateTracker.java
@@ -12,9 +12,24 @@ public final class GlStateTracker {
 	private static boolean supportVertexAttributeDivisor;
 	private static boolean isGl4ES = false;
 
+	private static final int SHADER_TEXTURE_COUNT = 8;
+
 	private static int vertArrayBinding;
 	private static int arrayBufBinding;
 	private static int elementBufBinding;
+	private static int activeTexture;
+	private static final int[] shaderTextures = new int[SHADER_TEXTURE_COUNT];
+	private static boolean blendEnabled;
+	private static boolean depthTestEnabled;
+	private static boolean cullEnabled;
+	private static boolean depthMask;
+	private static int depthFunc;
+	private static int blendSrcRgb;
+	private static int blendDstRgb;
+	private static int blendSrcAlpha;
+	private static int blendDstAlpha;
+	private static int blendEquationRgb;
+	private static int blendEquationAlpha;
 	private static ShaderProgram currentShaderProgram;
 	private static boolean isStateProtected;
 
@@ -31,6 +46,21 @@ public final class GlStateTracker {
 		vertArrayBinding = GL33.glGetInteger(GL33.GL_VERTEX_ARRAY_BINDING);
 		arrayBufBinding = GL33.glGetInteger(GL33.GL_ARRAY_BUFFER_BINDING);
 		elementBufBinding = GL33.glGetInteger(GL33.GL_ELEMENT_ARRAY_BUFFER_BINDING);
+		activeTexture = GL33.glGetInteger(GL33.GL_ACTIVE_TEXTURE);
+		for (int i = 0; i < SHADER_TEXTURE_COUNT; i++) {
+			shaderTextures[i] = RenderSystem.getShaderTexture(i);
+		}
+		blendEnabled = GL33.glIsEnabled(GL33.GL_BLEND);
+		depthTestEnabled = GL33.glIsEnabled(GL33.GL_DEPTH_TEST);
+		cullEnabled = GL33.glIsEnabled(GL33.GL_CULL_FACE);
+		depthMask = GL33.glGetBoolean(GL33.GL_DEPTH_WRITEMASK);
+		depthFunc = GL33.glGetInteger(GL33.GL_DEPTH_FUNC);
+		blendSrcRgb = GL33.glGetInteger(GL33.GL_BLEND_SRC_RGB);
+		blendDstRgb = GL33.glGetInteger(GL33.GL_BLEND_DST_RGB);
+		blendSrcAlpha = GL33.glGetInteger(GL33.GL_BLEND_SRC_ALPHA);
+		blendDstAlpha = GL33.glGetInteger(GL33.GL_BLEND_DST_ALPHA);
+		blendEquationRgb = GL33.glGetInteger(GL33.GL_BLEND_EQUATION_RGB);
+		blendEquationAlpha = GL33.glGetInteger(GL33.GL_BLEND_EQUATION_ALPHA);
 		currentShaderProgram = RenderSystem.getShader();
 		isStateProtected = true;
 	}
@@ -46,12 +76,44 @@ public final class GlStateTracker {
 		GL33.glBindBuffer(GL33.GL_ELEMENT_ARRAY_BUFFER, elementBufBinding);
 
 		RenderSystem.setShader(() -> currentShaderProgram);
+		for (int i = 0; i < SHADER_TEXTURE_COUNT; i++) {
+			RenderSystem.setShaderTexture(i, shaderTextures[i]);
+		}
+		GL33.glActiveTexture(activeTexture);
 
-		// Obtain original state from RenderSystem?
-		RenderSystem.enableCull();
-		RenderSystem.depthMask(true);
+		setBlend(blendEnabled);
+		setDepthTest(depthTestEnabled);
+		setCull(cullEnabled);
+		RenderSystem.depthMask(depthMask);
+		RenderSystem.depthFunc(depthFunc);
+		GL33.glBlendFuncSeparate(blendSrcRgb, blendDstRgb, blendSrcAlpha, blendDstAlpha);
+		GL33.glBlendEquationSeparate(blendEquationRgb, blendEquationAlpha);
 
 		isStateProtected = false;
+	}
+
+	private static void setBlend(boolean enabled) {
+		if (enabled) {
+			RenderSystem.enableBlend();
+		} else {
+			RenderSystem.disableBlend();
+		}
+	}
+
+	private static void setDepthTest(boolean enabled) {
+		if (enabled) {
+			RenderSystem.enableDepthTest();
+		} else {
+			RenderSystem.disableDepthTest();
+		}
+	}
+
+	private static void setCull(boolean enabled) {
+		if (enabled) {
+			RenderSystem.enableCull();
+		} else {
+			RenderSystem.disableCull();
+		}
 	}
 
 	public static void assertProtected() {

--- a/fabric/1.20.1-mapping/src/main/java/org/mtr/mapping/mapper/GraphicsHolder.java
+++ b/fabric/1.20.1-mapping/src/main/java/org/mtr/mapping/mapper/GraphicsHolder.java
@@ -144,6 +144,11 @@ public final class GraphicsHolder extends DummyClass {
 	}
 
 	@MappedMethod
+	public org.mtr.mapping.holder.Matrix4f copyPositionMatrix() {
+		return matrixStack == null ? new org.mtr.mapping.holder.Matrix4f() : new org.mtr.mapping.holder.Matrix4f(matrixStack.peek().getPositionMatrix());
+	}
+
+	@MappedMethod
 	public void drawText(MutableText mutableText, int x, int y, int color, boolean shadow, int light) {
 		if (matrixStack != null) {
 			final VertexConsumerProvider.Immediate immediate = drawContext == null ? VertexConsumerProvider.immediate(Tessellator.getInstance().getBuffer()) : drawContext.getVertexConsumers();

--- a/fabric/1.20.1-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/fabric/1.20.1-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -119,13 +119,10 @@ public final class OptimizedModel extends DummyClass {
 		private final RawModel rawModel = new RawModel();
 
 		private ObjModel(
-				List<RawMesh> rawMeshes, boolean flipTextureV,
+				List<RawMesh> rawMeshes,
 				float minX, float minY, float minZ,
 				float maxX, float maxY, float maxZ
 		) {
-			if (flipTextureV) {
-				rawMeshes.forEach(rawMesh -> rawMesh.applyUVMirror(false, true));
-			}
 			this.minX = minX;
 			this.minY = minY;
 			this.minZ = minZ;
@@ -143,9 +140,9 @@ public final class OptimizedModel extends DummyClass {
 
 			final Map<String, ObjModel> objModels = new HashMap<>();
 			ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel).forEach((key, rawMeshes) -> {
+				prepareRawMeshes(rawMeshes, flipTextureV);
 				final float[] bounds = {Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE};
 				rawMeshes.forEach(rawMesh -> {
-					rawMesh.applyRotation(new Vector3f(1, 0, 0), 180);
 					rawMesh.vertices.forEach(vertex -> {
 						final float x = vertex.position.getX();
 						final float y = vertex.position.getY();
@@ -158,10 +155,21 @@ public final class OptimizedModel extends DummyClass {
 						bounds[5] = Math.max(bounds[5], z);
 					});
 				});
-				objModels.put(key, new ObjModel(rawMeshes, flipTextureV, bounds[0], bounds[1], bounds[2], bounds[3], bounds[4], bounds[5]));
+				objModels.put(key, new ObjModel(rawMeshes, bounds[0], bounds[1], bounds[2], bounds[3], bounds[4], bounds[5]));
 			});
 
 			return objModels;
+		}
+
+		@MappedMethod
+		public static Map<String, List<RawMesh>> loadRawModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, @Nullable Identifier atlasIndex, boolean splitModel, boolean flipTextureV) {
+			if (atlasIndex != null) {
+				ATLAS_MANAGER.load(atlasIndex);
+			}
+
+			final Map<String, List<RawMesh>> rawModels = ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel);
+			rawModels.values().forEach(rawMeshes -> prepareRawMeshes(rawMeshes, flipTextureV));
+			return rawModels;
 		}
 
 		@MappedMethod
@@ -229,6 +237,15 @@ public final class OptimizedModel extends DummyClass {
 		public float getMaxZ() {
 			return maxZ;
 		}
+		private static void prepareRawMeshes(List<RawMesh> rawMeshes, boolean flipTextureV) {
+			rawMeshes.forEach(rawMesh -> {
+				rawMesh.applyRotation(new Vector3f(1, 0, 0), 180);
+				if (flipTextureV) {
+					rawMesh.applyUVMirror(false, true);
+				}
+			});
+		}
+
 	}
 
 	public enum ShaderType {

--- a/fabric/1.20.1-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedRenderer.java
+++ b/fabric/1.20.1-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedRenderer.java
@@ -10,20 +10,49 @@ import org.mtr.mapping.render.tool.Utilities;
 import org.mtr.mapping.render.vertex.VertexAttributeState;
 import org.mtr.mapping.tool.DummyClass;
 
+import java.util.function.Supplier;
+
 public final class OptimizedRenderer extends DummyClass {
 
 	private final BatchManager batchManager = new BatchManager();
 	private final ShaderManager shaderManager = new ShaderManager();
+	private int protectedDepth;
+	private int reloadDepth;
 
 	@MappedMethod
 	public void beginReload() {
-		shaderManager.reloadShaders();
-		GlStateTracker.capture();
+		if (reloadDepth++ == 0) {
+			shaderManager.reloadShaders();
+		}
+		beginProtectedState();
 	}
 
 	@MappedMethod
 	public void finishReload() {
-		GlStateTracker.restore();
+		if (reloadDepth > 0) {
+			reloadDepth--;
+			finishProtectedState();
+		}
+	}
+
+	@MappedMethod
+	public void runWithProtectedState(Runnable runnable) {
+		beginProtectedState();
+		try {
+			runnable.run();
+		} finally {
+			finishProtectedState();
+		}
+	}
+
+	@MappedMethod
+	public <T> T runWithProtectedState(Supplier<T> supplier) {
+		beginProtectedState();
+		try {
+			return supplier.get();
+		} finally {
+			finishProtectedState();
+		}
 	}
 
 	@MappedMethod
@@ -36,9 +65,7 @@ public final class OptimizedRenderer extends DummyClass {
 	@MappedMethod
 	public void render(boolean renderTranslucent) {
 		if (shaderManager.isReady()) {
-			GlStateTracker.capture();
-			batchManager.drawAll(shaderManager, renderTranslucent);
-			GlStateTracker.restore();
+			runWithProtectedState(() -> batchManager.drawAll(shaderManager, renderTranslucent));
 		}
 	}
 
@@ -53,5 +80,17 @@ public final class OptimizedRenderer extends DummyClass {
 	@MappedMethod
 	public static boolean hasOptimizedRendering() {
 		return true;
+	}
+
+	private void beginProtectedState() {
+		if (protectedDepth++ == 0) {
+			GlStateTracker.capture();
+		}
+	}
+
+	private void finishProtectedState() {
+		if (protectedDepth > 0 && --protectedDepth == 0) {
+			GlStateTracker.restore();
+		}
 	}
 }

--- a/fabric/1.20.1-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
+++ b/fabric/1.20.1-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
@@ -108,7 +108,9 @@ public final class ObjModelLoader {
 					mesh.faces.add(new Face(new int[]{face.getVertexIndex(0), face.getVertexIndex(1), face.getVertexIndex(2)}));
 				}
 
-				atlasManager.applyToMesh(mesh);
+				if (atlasManager != null) {
+					atlasManager.applyToMesh(mesh);
+				}
 				mesh.validateVertexIndex();
 				rawMeshes.add(mesh);
 			}

--- a/fabric/1.20.1-mapping/src/main/java/org/mtr/mapping/render/object/InstancedDrawHelper.java
+++ b/fabric/1.20.1-mapping/src/main/java/org/mtr/mapping/render/object/InstancedDrawHelper.java
@@ -1,0 +1,71 @@
+package org.mtr.mapping.render.object;
+
+import org.lwjgl.opengl.ARBInstancedArrays;
+import org.lwjgl.opengl.GL;
+import org.lwjgl.opengl.GL33;
+import org.mtr.mapping.render.vertex.VertexAttributeMapping;
+import org.mtr.mapping.render.vertex.VertexAttributeType;
+
+import java.nio.ByteBuffer;
+
+public final class InstancedDrawHelper {
+
+	public static boolean setupInstanceAttributes(VertexArray vertexArray, VertexBuffer instanceBuffer, VertexAttributeMapping mapping, VertexAttributeType... vertexAttributeTypes) {
+		vertexArray.bind();
+		instanceBuffer.bind(GL33.GL_ARRAY_BUFFER);
+		boolean supported = true;
+		for (final VertexAttributeType vertexAttributeType : vertexAttributeTypes) {
+			supported &= setupInstanceAttribute(mapping, vertexAttributeType);
+		}
+		VertexArray.unbind();
+		return supported;
+	}
+
+	public static void setupInstanceAttributePointers(VertexBuffer instanceBuffer, VertexAttributeMapping mapping, int instanceOffsetBytes, VertexAttributeType... vertexAttributeTypes) {
+		instanceBuffer.bind(GL33.GL_ARRAY_BUFFER);
+		for (final VertexAttributeType vertexAttributeType : vertexAttributeTypes) {
+			vertexAttributeType.setupAttributePointer(mapping.strideInstance, instanceOffsetBytes + mapping.pointers.get(vertexAttributeType));
+		}
+	}
+
+	public static void uploadInstances(VertexBuffer instanceBuffer, ByteBuffer byteBuffer, int size) {
+		instanceBuffer.bind(GL33.GL_ARRAY_BUFFER);
+		instanceBuffer.upload(byteBuffer, size, VertexBuffer.USAGE_STREAM_DRAW);
+	}
+
+	public static void drawElementsInstanced(VertexArray vertexArray, int instanceCount) {
+		GL33.glDrawElementsInstanced(GL33.GL_TRIANGLES, vertexArray.indexBuffer.getVertexCount(), vertexArray.indexBuffer.indexType, 0, instanceCount);
+	}
+
+	private static boolean setupInstanceAttribute(VertexAttributeMapping mapping, VertexAttributeType vertexAttributeType) {
+		vertexAttributeType.toggleAttributeArray(true);
+		vertexAttributeType.setupAttributePointer(mapping.strideInstance, mapping.pointers.get(vertexAttributeType));
+		return applyInstanceAttributeDivisor(vertexAttributeType);
+	}
+
+	private static boolean applyInstanceAttributeDivisor(VertexAttributeType vertexAttributeType) {
+		boolean supported = true;
+		for (int i = 0; i < vertexAttributeType.span; i++) {
+			supported &= applyInstanceAttributeDivisor(vertexAttributeType.location + i);
+		}
+		return supported;
+	}
+
+	private static boolean applyInstanceAttributeDivisor(int location) {
+		try {
+			final org.lwjgl.opengl.GLCapabilities capabilities = GL.getCapabilities();
+			if (capabilities.OpenGL33) {
+				GL33.glVertexAttribDivisor(location, 1);
+				return true;
+			} else if (capabilities.GL_ARB_instanced_arrays) {
+				ARBInstancedArrays.glVertexAttribDivisorARB(location, 1);
+				return true;
+			}
+		} catch (IllegalStateException ignored) {
+		}
+		return false;
+	}
+
+	private InstancedDrawHelper() {
+	}
+}

--- a/fabric/1.20.1-mapping/src/main/java/org/mtr/mapping/render/shader/PatchingResourceProvider.java
+++ b/fabric/1.20.1-mapping/src/main/java/org/mtr/mapping/render/shader/PatchingResourceProvider.java
@@ -41,8 +41,10 @@ public final class PatchingResourceProvider implements ResourceFactory {
 					inputStream.close();
 					dataObject.addProperty("vertex", dataObject.get("vertex").getAsString() + "_modelmat");
 					final JsonArray attributeArray = dataObject.get("attributes").getAsJsonArray();
-					for (int i = 0; i < 6 - attributeArray.size(); i++) {
-						attributeArray.add("Dummy" + i);
+					int dummyIndex = 0;
+					while (attributeArray.size() < 6) {
+						attributeArray.add("Dummy" + dummyIndex);
+						dummyIndex++;
 					}
 					attributeArray.add("ModelMat");
 					returningContent = dataObject.toString();

--- a/fabric/1.20.1-mapping/src/main/java/org/mtr/mapping/render/tool/GlStateTracker.java
+++ b/fabric/1.20.1-mapping/src/main/java/org/mtr/mapping/render/tool/GlStateTracker.java
@@ -12,9 +12,24 @@ public final class GlStateTracker {
 	private static boolean supportVertexAttributeDivisor;
 	private static boolean isGl4ES = false;
 
+	private static final int SHADER_TEXTURE_COUNT = 8;
+
 	private static int vertArrayBinding;
 	private static int arrayBufBinding;
 	private static int elementBufBinding;
+	private static int activeTexture;
+	private static final int[] shaderTextures = new int[SHADER_TEXTURE_COUNT];
+	private static boolean blendEnabled;
+	private static boolean depthTestEnabled;
+	private static boolean cullEnabled;
+	private static boolean depthMask;
+	private static int depthFunc;
+	private static int blendSrcRgb;
+	private static int blendDstRgb;
+	private static int blendSrcAlpha;
+	private static int blendDstAlpha;
+	private static int blendEquationRgb;
+	private static int blendEquationAlpha;
 	private static ShaderProgram currentShaderProgram;
 	private static boolean isStateProtected;
 
@@ -31,6 +46,21 @@ public final class GlStateTracker {
 		vertArrayBinding = GL33.glGetInteger(GL33.GL_VERTEX_ARRAY_BINDING);
 		arrayBufBinding = GL33.glGetInteger(GL33.GL_ARRAY_BUFFER_BINDING);
 		elementBufBinding = GL33.glGetInteger(GL33.GL_ELEMENT_ARRAY_BUFFER_BINDING);
+		activeTexture = GL33.glGetInteger(GL33.GL_ACTIVE_TEXTURE);
+		for (int i = 0; i < SHADER_TEXTURE_COUNT; i++) {
+			shaderTextures[i] = RenderSystem.getShaderTexture(i);
+		}
+		blendEnabled = GL33.glIsEnabled(GL33.GL_BLEND);
+		depthTestEnabled = GL33.glIsEnabled(GL33.GL_DEPTH_TEST);
+		cullEnabled = GL33.glIsEnabled(GL33.GL_CULL_FACE);
+		depthMask = GL33.glGetBoolean(GL33.GL_DEPTH_WRITEMASK);
+		depthFunc = GL33.glGetInteger(GL33.GL_DEPTH_FUNC);
+		blendSrcRgb = GL33.glGetInteger(GL33.GL_BLEND_SRC_RGB);
+		blendDstRgb = GL33.glGetInteger(GL33.GL_BLEND_DST_RGB);
+		blendSrcAlpha = GL33.glGetInteger(GL33.GL_BLEND_SRC_ALPHA);
+		blendDstAlpha = GL33.glGetInteger(GL33.GL_BLEND_DST_ALPHA);
+		blendEquationRgb = GL33.glGetInteger(GL33.GL_BLEND_EQUATION_RGB);
+		blendEquationAlpha = GL33.glGetInteger(GL33.GL_BLEND_EQUATION_ALPHA);
 		currentShaderProgram = RenderSystem.getShader();
 		isStateProtected = true;
 	}
@@ -46,12 +76,44 @@ public final class GlStateTracker {
 		GL33.glBindBuffer(GL33.GL_ELEMENT_ARRAY_BUFFER, elementBufBinding);
 
 		RenderSystem.setShader(() -> currentShaderProgram);
+		for (int i = 0; i < SHADER_TEXTURE_COUNT; i++) {
+			RenderSystem.setShaderTexture(i, shaderTextures[i]);
+		}
+		GL33.glActiveTexture(activeTexture);
 
-		// Obtain original state from RenderSystem?
-		RenderSystem.enableCull();
-		RenderSystem.depthMask(true);
+		setBlend(blendEnabled);
+		setDepthTest(depthTestEnabled);
+		setCull(cullEnabled);
+		RenderSystem.depthMask(depthMask);
+		RenderSystem.depthFunc(depthFunc);
+		GL33.glBlendFuncSeparate(blendSrcRgb, blendDstRgb, blendSrcAlpha, blendDstAlpha);
+		GL33.glBlendEquationSeparate(blendEquationRgb, blendEquationAlpha);
 
 		isStateProtected = false;
+	}
+
+	private static void setBlend(boolean enabled) {
+		if (enabled) {
+			RenderSystem.enableBlend();
+		} else {
+			RenderSystem.disableBlend();
+		}
+	}
+
+	private static void setDepthTest(boolean enabled) {
+		if (enabled) {
+			RenderSystem.enableDepthTest();
+		} else {
+			RenderSystem.disableDepthTest();
+		}
+	}
+
+	private static void setCull(boolean enabled) {
+		if (enabled) {
+			RenderSystem.enableCull();
+		} else {
+			RenderSystem.disableCull();
+		}
 	}
 
 	public static void assertProtected() {

--- a/fabric/1.20.4-mapping/src/main/java/org/mtr/mapping/mapper/GraphicsHolder.java
+++ b/fabric/1.20.4-mapping/src/main/java/org/mtr/mapping/mapper/GraphicsHolder.java
@@ -144,6 +144,11 @@ public final class GraphicsHolder extends DummyClass {
 	}
 
 	@MappedMethod
+	public org.mtr.mapping.holder.Matrix4f copyPositionMatrix() {
+		return matrixStack == null ? new org.mtr.mapping.holder.Matrix4f() : new org.mtr.mapping.holder.Matrix4f(matrixStack.peek().getPositionMatrix());
+	}
+
+	@MappedMethod
 	public void drawText(MutableText mutableText, int x, int y, int color, boolean shadow, int light) {
 		if (matrixStack != null) {
 			final VertexConsumerProvider.Immediate immediate = drawContext == null ? VertexConsumerProvider.immediate(Tessellator.getInstance().getBuffer()) : drawContext.getVertexConsumers();

--- a/fabric/1.20.4-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/fabric/1.20.4-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -119,13 +119,10 @@ public final class OptimizedModel extends DummyClass {
 		private final RawModel rawModel = new RawModel();
 
 		private ObjModel(
-				List<RawMesh> rawMeshes, boolean flipTextureV,
+				List<RawMesh> rawMeshes,
 				float minX, float minY, float minZ,
 				float maxX, float maxY, float maxZ
 		) {
-			if (flipTextureV) {
-				rawMeshes.forEach(rawMesh -> rawMesh.applyUVMirror(false, true));
-			}
 			this.minX = minX;
 			this.minY = minY;
 			this.minZ = minZ;
@@ -143,9 +140,9 @@ public final class OptimizedModel extends DummyClass {
 
 			final Map<String, ObjModel> objModels = new HashMap<>();
 			ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel).forEach((key, rawMeshes) -> {
+				prepareRawMeshes(rawMeshes, flipTextureV);
 				final float[] bounds = {Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE};
 				rawMeshes.forEach(rawMesh -> {
-					rawMesh.applyRotation(new Vector3f(1, 0, 0), 180);
 					rawMesh.vertices.forEach(vertex -> {
 						final float x = vertex.position.getX();
 						final float y = vertex.position.getY();
@@ -158,10 +155,21 @@ public final class OptimizedModel extends DummyClass {
 						bounds[5] = Math.max(bounds[5], z);
 					});
 				});
-				objModels.put(key, new ObjModel(rawMeshes, flipTextureV, bounds[0], bounds[1], bounds[2], bounds[3], bounds[4], bounds[5]));
+				objModels.put(key, new ObjModel(rawMeshes, bounds[0], bounds[1], bounds[2], bounds[3], bounds[4], bounds[5]));
 			});
 
 			return objModels;
+		}
+
+		@MappedMethod
+		public static Map<String, List<RawMesh>> loadRawModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, @Nullable Identifier atlasIndex, boolean splitModel, boolean flipTextureV) {
+			if (atlasIndex != null) {
+				ATLAS_MANAGER.load(atlasIndex);
+			}
+
+			final Map<String, List<RawMesh>> rawModels = ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel);
+			rawModels.values().forEach(rawMeshes -> prepareRawMeshes(rawMeshes, flipTextureV));
+			return rawModels;
 		}
 
 		@MappedMethod
@@ -228,6 +236,15 @@ public final class OptimizedModel extends DummyClass {
 		@MappedMethod
 		public float getMaxZ() {
 			return maxZ;
+		}
+
+		private static void prepareRawMeshes(List<RawMesh> rawMeshes, boolean flipTextureV) {
+			rawMeshes.forEach(rawMesh -> {
+				rawMesh.applyRotation(new Vector3f(1, 0, 0), 180);
+				if (flipTextureV) {
+					rawMesh.applyUVMirror(false, true);
+				}
+			});
 		}
 	}
 

--- a/fabric/1.20.4-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedRenderer.java
+++ b/fabric/1.20.4-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedRenderer.java
@@ -10,20 +10,49 @@ import org.mtr.mapping.render.tool.Utilities;
 import org.mtr.mapping.render.vertex.VertexAttributeState;
 import org.mtr.mapping.tool.DummyClass;
 
+import java.util.function.Supplier;
+
 public final class OptimizedRenderer extends DummyClass {
 
 	private final BatchManager batchManager = new BatchManager();
 	private final ShaderManager shaderManager = new ShaderManager();
+	private int protectedDepth;
+	private int reloadDepth;
 
 	@MappedMethod
 	public void beginReload() {
-		shaderManager.reloadShaders();
-		GlStateTracker.capture();
+		if (reloadDepth++ == 0) {
+			shaderManager.reloadShaders();
+		}
+		beginProtectedState();
 	}
 
 	@MappedMethod
 	public void finishReload() {
-		GlStateTracker.restore();
+		if (reloadDepth > 0) {
+			reloadDepth--;
+			finishProtectedState();
+		}
+	}
+
+	@MappedMethod
+	public void runWithProtectedState(Runnable runnable) {
+		beginProtectedState();
+		try {
+			runnable.run();
+		} finally {
+			finishProtectedState();
+		}
+	}
+
+	@MappedMethod
+	public <T> T runWithProtectedState(Supplier<T> supplier) {
+		beginProtectedState();
+		try {
+			return supplier.get();
+		} finally {
+			finishProtectedState();
+		}
 	}
 
 	@MappedMethod
@@ -36,9 +65,7 @@ public final class OptimizedRenderer extends DummyClass {
 	@MappedMethod
 	public void render(boolean renderTranslucent) {
 		if (shaderManager.isReady()) {
-			GlStateTracker.capture();
-			batchManager.drawAll(shaderManager, renderTranslucent);
-			GlStateTracker.restore();
+			runWithProtectedState(() -> batchManager.drawAll(shaderManager, renderTranslucent));
 		}
 	}
 
@@ -53,5 +80,17 @@ public final class OptimizedRenderer extends DummyClass {
 	@MappedMethod
 	public static boolean hasOptimizedRendering() {
 		return true;
+	}
+
+	private void beginProtectedState() {
+		if (protectedDepth++ == 0) {
+			GlStateTracker.capture();
+		}
+	}
+
+	private void finishProtectedState() {
+		if (protectedDepth > 0 && --protectedDepth == 0) {
+			GlStateTracker.restore();
+		}
 	}
 }

--- a/fabric/1.20.4-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
+++ b/fabric/1.20.4-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
@@ -50,7 +50,11 @@ public final class ObjModelLoader {
 	private static List<RawMesh> loadModel(Obj sourceObj, Map<String, Mtl> materials, Function<String, Identifier> textureResolver, AtlasManager atlasManager) {
 		final List<RawMesh> rawMeshes = new ArrayList<>();
 
-		ObjSplitting.splitByMaterialGroups(sourceObj).forEach((key, obj) -> {
+		final Map<String, Obj> materialGroups = ObjSplitting.splitByMaterialGroups(sourceObj);
+		if (materialGroups.isEmpty() && sourceObj.getNumFaces() > 0) {
+			materialGroups.put("", sourceObj);
+		}
+		materialGroups.forEach((key, obj) -> {
 			if (obj.getNumFaces() > 0) {
 				final Map<String, String> materialOptions = splitMaterialOptions(key);
 				final String materialGroupName = materialOptions.get("");

--- a/fabric/1.20.4-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
+++ b/fabric/1.20.4-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
@@ -108,7 +108,9 @@ public final class ObjModelLoader {
 					mesh.faces.add(new Face(new int[]{face.getVertexIndex(0), face.getVertexIndex(1), face.getVertexIndex(2)}));
 				}
 
-				atlasManager.applyToMesh(mesh);
+				if (atlasManager != null) {
+					atlasManager.applyToMesh(mesh);
+				}
 				mesh.validateVertexIndex();
 				rawMeshes.add(mesh);
 			}

--- a/fabric/1.20.4-mapping/src/main/java/org/mtr/mapping/render/object/InstancedDrawHelper.java
+++ b/fabric/1.20.4-mapping/src/main/java/org/mtr/mapping/render/object/InstancedDrawHelper.java
@@ -1,0 +1,71 @@
+package org.mtr.mapping.render.object;
+
+import org.lwjgl.opengl.ARBInstancedArrays;
+import org.lwjgl.opengl.GL;
+import org.lwjgl.opengl.GL33;
+import org.mtr.mapping.render.vertex.VertexAttributeMapping;
+import org.mtr.mapping.render.vertex.VertexAttributeType;
+
+import java.nio.ByteBuffer;
+
+public final class InstancedDrawHelper {
+
+	public static boolean setupInstanceAttributes(VertexArray vertexArray, VertexBuffer instanceBuffer, VertexAttributeMapping mapping, VertexAttributeType... vertexAttributeTypes) {
+		vertexArray.bind();
+		instanceBuffer.bind(GL33.GL_ARRAY_BUFFER);
+		boolean supported = true;
+		for (final VertexAttributeType vertexAttributeType : vertexAttributeTypes) {
+			supported &= setupInstanceAttribute(mapping, vertexAttributeType);
+		}
+		VertexArray.unbind();
+		return supported;
+	}
+
+	public static void setupInstanceAttributePointers(VertexBuffer instanceBuffer, VertexAttributeMapping mapping, int instanceOffsetBytes, VertexAttributeType... vertexAttributeTypes) {
+		instanceBuffer.bind(GL33.GL_ARRAY_BUFFER);
+		for (final VertexAttributeType vertexAttributeType : vertexAttributeTypes) {
+			vertexAttributeType.setupAttributePointer(mapping.strideInstance, instanceOffsetBytes + mapping.pointers.get(vertexAttributeType));
+		}
+	}
+
+	public static void uploadInstances(VertexBuffer instanceBuffer, ByteBuffer byteBuffer, int size) {
+		instanceBuffer.bind(GL33.GL_ARRAY_BUFFER);
+		instanceBuffer.upload(byteBuffer, size, VertexBuffer.USAGE_STREAM_DRAW);
+	}
+
+	public static void drawElementsInstanced(VertexArray vertexArray, int instanceCount) {
+		GL33.glDrawElementsInstanced(GL33.GL_TRIANGLES, vertexArray.indexBuffer.getVertexCount(), vertexArray.indexBuffer.indexType, 0, instanceCount);
+	}
+
+	private static boolean setupInstanceAttribute(VertexAttributeMapping mapping, VertexAttributeType vertexAttributeType) {
+		vertexAttributeType.toggleAttributeArray(true);
+		vertexAttributeType.setupAttributePointer(mapping.strideInstance, mapping.pointers.get(vertexAttributeType));
+		return applyInstanceAttributeDivisor(vertexAttributeType);
+	}
+
+	private static boolean applyInstanceAttributeDivisor(VertexAttributeType vertexAttributeType) {
+		boolean supported = true;
+		for (int i = 0; i < vertexAttributeType.span; i++) {
+			supported &= applyInstanceAttributeDivisor(vertexAttributeType.location + i);
+		}
+		return supported;
+	}
+
+	private static boolean applyInstanceAttributeDivisor(int location) {
+		try {
+			final org.lwjgl.opengl.GLCapabilities capabilities = GL.getCapabilities();
+			if (capabilities.OpenGL33) {
+				GL33.glVertexAttribDivisor(location, 1);
+				return true;
+			} else if (capabilities.GL_ARB_instanced_arrays) {
+				ARBInstancedArrays.glVertexAttribDivisorARB(location, 1);
+				return true;
+			}
+		} catch (IllegalStateException ignored) {
+		}
+		return false;
+	}
+
+	private InstancedDrawHelper() {
+	}
+}

--- a/fabric/1.20.4-mapping/src/main/java/org/mtr/mapping/render/shader/PatchingResourceProvider.java
+++ b/fabric/1.20.4-mapping/src/main/java/org/mtr/mapping/render/shader/PatchingResourceProvider.java
@@ -41,8 +41,10 @@ public final class PatchingResourceProvider implements ResourceFactory {
 					inputStream.close();
 					dataObject.addProperty("vertex", dataObject.get("vertex").getAsString() + "_modelmat");
 					final JsonArray attributeArray = dataObject.get("attributes").getAsJsonArray();
-					for (int i = 0; i < 6 - attributeArray.size(); i++) {
-						attributeArray.add("Dummy" + i);
+					int dummyIndex = 0;
+					while (attributeArray.size() < 6) {
+						attributeArray.add("Dummy" + dummyIndex);
+						dummyIndex++;
 					}
 					attributeArray.add("ModelMat");
 					returningContent = dataObject.toString();

--- a/fabric/1.20.4-mapping/src/main/java/org/mtr/mapping/render/tool/GlStateTracker.java
+++ b/fabric/1.20.4-mapping/src/main/java/org/mtr/mapping/render/tool/GlStateTracker.java
@@ -12,9 +12,24 @@ public final class GlStateTracker {
 	private static boolean supportVertexAttributeDivisor;
 	private static boolean isGl4ES = false;
 
+	private static final int SHADER_TEXTURE_COUNT = 8;
+
 	private static int vertArrayBinding;
 	private static int arrayBufBinding;
 	private static int elementBufBinding;
+	private static int activeTexture;
+	private static final int[] shaderTextures = new int[SHADER_TEXTURE_COUNT];
+	private static boolean blendEnabled;
+	private static boolean depthTestEnabled;
+	private static boolean cullEnabled;
+	private static boolean depthMask;
+	private static int depthFunc;
+	private static int blendSrcRgb;
+	private static int blendDstRgb;
+	private static int blendSrcAlpha;
+	private static int blendDstAlpha;
+	private static int blendEquationRgb;
+	private static int blendEquationAlpha;
 	private static ShaderProgram currentShaderProgram;
 	private static boolean isStateProtected;
 
@@ -31,6 +46,21 @@ public final class GlStateTracker {
 		vertArrayBinding = GL33.glGetInteger(GL33.GL_VERTEX_ARRAY_BINDING);
 		arrayBufBinding = GL33.glGetInteger(GL33.GL_ARRAY_BUFFER_BINDING);
 		elementBufBinding = GL33.glGetInteger(GL33.GL_ELEMENT_ARRAY_BUFFER_BINDING);
+		activeTexture = GL33.glGetInteger(GL33.GL_ACTIVE_TEXTURE);
+		for (int i = 0; i < SHADER_TEXTURE_COUNT; i++) {
+			shaderTextures[i] = RenderSystem.getShaderTexture(i);
+		}
+		blendEnabled = GL33.glIsEnabled(GL33.GL_BLEND);
+		depthTestEnabled = GL33.glIsEnabled(GL33.GL_DEPTH_TEST);
+		cullEnabled = GL33.glIsEnabled(GL33.GL_CULL_FACE);
+		depthMask = GL33.glGetBoolean(GL33.GL_DEPTH_WRITEMASK);
+		depthFunc = GL33.glGetInteger(GL33.GL_DEPTH_FUNC);
+		blendSrcRgb = GL33.glGetInteger(GL33.GL_BLEND_SRC_RGB);
+		blendDstRgb = GL33.glGetInteger(GL33.GL_BLEND_DST_RGB);
+		blendSrcAlpha = GL33.glGetInteger(GL33.GL_BLEND_SRC_ALPHA);
+		blendDstAlpha = GL33.glGetInteger(GL33.GL_BLEND_DST_ALPHA);
+		blendEquationRgb = GL33.glGetInteger(GL33.GL_BLEND_EQUATION_RGB);
+		blendEquationAlpha = GL33.glGetInteger(GL33.GL_BLEND_EQUATION_ALPHA);
 		currentShaderProgram = RenderSystem.getShader();
 		isStateProtected = true;
 	}
@@ -46,12 +76,44 @@ public final class GlStateTracker {
 		GL33.glBindBuffer(GL33.GL_ELEMENT_ARRAY_BUFFER, elementBufBinding);
 
 		RenderSystem.setShader(() -> currentShaderProgram);
+		for (int i = 0; i < SHADER_TEXTURE_COUNT; i++) {
+			RenderSystem.setShaderTexture(i, shaderTextures[i]);
+		}
+		GL33.glActiveTexture(activeTexture);
 
-		// Obtain original state from RenderSystem?
-		RenderSystem.enableCull();
-		RenderSystem.depthMask(true);
+		setBlend(blendEnabled);
+		setDepthTest(depthTestEnabled);
+		setCull(cullEnabled);
+		RenderSystem.depthMask(depthMask);
+		RenderSystem.depthFunc(depthFunc);
+		GL33.glBlendFuncSeparate(blendSrcRgb, blendDstRgb, blendSrcAlpha, blendDstAlpha);
+		GL33.glBlendEquationSeparate(blendEquationRgb, blendEquationAlpha);
 
 		isStateProtected = false;
+	}
+
+	private static void setBlend(boolean enabled) {
+		if (enabled) {
+			RenderSystem.enableBlend();
+		} else {
+			RenderSystem.disableBlend();
+		}
+	}
+
+	private static void setDepthTest(boolean enabled) {
+		if (enabled) {
+			RenderSystem.enableDepthTest();
+		} else {
+			RenderSystem.disableDepthTest();
+		}
+	}
+
+	private static void setCull(boolean enabled) {
+		if (enabled) {
+			RenderSystem.enableCull();
+		} else {
+			RenderSystem.disableCull();
+		}
 	}
 
 	public static void assertProtected() {

--- a/fabric/1.20.4-mapping/src/test/java/org/mtr/mapping/mapper/OptimizedModelObjModelTest.java
+++ b/fabric/1.20.4-mapping/src/test/java/org/mtr/mapping/mapper/OptimizedModelObjModelTest.java
@@ -1,0 +1,55 @@
+package org.mtr.mapping.mapper;
+
+import org.junit.jupiter.api.Test;
+import org.mtr.mapping.holder.Identifier;
+import org.mtr.mapping.render.model.RawMesh;
+import org.mtr.mapping.render.vertex.Vertex;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class OptimizedModelObjModelTest {
+
+	private static final String SIMPLE_OBJ = String.join("\n",
+			"v 0 0 0",
+			"v 1 0 0",
+			"v 0 1 0",
+			"vt 0.25 0.75",
+			"vt 0.5 0.25",
+			"vt 0.75 0.5",
+			"vn 0 0 1",
+			"f 1/1/1 2/2/1 3/3/1"
+	);
+
+	@Test
+	public void loadRawModelWithoutAtlasIndexAppliesObjModelTransforms() {
+		final Map<String, List<RawMesh>> rawModels = OptimizedModel.ObjModel.loadRawModel(SIMPLE_OBJ, mtlString -> "", textureString -> new Identifier("minecraft:test"), null, false, false);
+		final List<RawMesh> rawMeshes = rawModels.get("");
+
+		assertFalse(rawModels.isEmpty());
+		assertEquals(1, rawMeshes.size());
+
+		final Vertex firstVertex = rawMeshes.get(0).vertices.get(0);
+		final Vertex thirdVertex = rawMeshes.get(0).vertices.get(2);
+		assertEquals(0, firstVertex.position.getX(), 0.0001F);
+		assertEquals(0, firstVertex.position.getY(), 0.0001F);
+		assertEquals(0, firstVertex.position.getZ(), 0.0001F);
+		assertEquals(0, thirdVertex.position.getX(), 0.0001F);
+		assertEquals(-1, thirdVertex.position.getY(), 0.0001F);
+		assertEquals(0, thirdVertex.position.getZ(), 0.0001F);
+		assertEquals(0.75F, firstVertex.v, 0.0001F);
+	}
+
+	@Test
+	public void loadRawModelRespectsFlipTextureV() {
+		final Map<String, List<RawMesh>> rawModels = OptimizedModel.ObjModel.loadRawModel(SIMPLE_OBJ, mtlString -> "", textureString -> new Identifier("minecraft:test"), null, false, true);
+		final Vertex firstVertex = rawModels.get("").get(0).vertices.get(0);
+		final Vertex secondVertex = rawModels.get("").get(0).vertices.get(1);
+
+		assertEquals(0.25F, firstVertex.v, 0.0001F);
+		assertEquals(0.75F, secondVertex.v, 0.0001F);
+	}
+}

--- a/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/mapper/GraphicsHolder.java
+++ b/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/mapper/GraphicsHolder.java
@@ -127,6 +127,11 @@ public final class GraphicsHolder extends DummyClass {
 	}
 
 	@MappedMethod
+	public org.mtr.mapping.holder.Matrix4f copyPositionMatrix() {
+		return matrixStack == null ? new org.mtr.mapping.holder.Matrix4f() : new org.mtr.mapping.holder.Matrix4f(matrixStack.last().pose());
+	}
+
+	@MappedMethod
 	public void drawText(MutableText mutableText, int x, int y, int color, boolean shadow, int light) {
 		if (matrixStack != null) {
 			final IRenderTypeBuffer.Impl immediate = IRenderTypeBuffer.immediate(Tessellator.getInstance().getBuilder());

--- a/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/render/batch/MaterialProperties.java
+++ b/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/render/batch/MaterialProperties.java
@@ -1,0 +1,55 @@
+package org.mtr.mapping.render.batch;
+
+import org.mtr.mapping.holder.Identifier;
+import org.mtr.mapping.mapper.OptimizedModel;
+import org.mtr.mapping.render.vertex.VertexAttributeState;
+
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+public final class MaterialProperties {
+
+	private Identifier texture;
+	public final OptimizedModel.ShaderType shaderType;
+	public final VertexAttributeState vertexAttributeState;
+	public final boolean translucent;
+	public final boolean writeDepthBuf;
+	public final boolean cutoutHack;
+
+	public MaterialProperties(OptimizedModel.ShaderType shaderType, Identifier texture, @Nullable Integer color) {
+		this.shaderType = shaderType;
+		this.texture = texture;
+		translucent = shaderType == OptimizedModel.ShaderType.TRANSLUCENT || shaderType == OptimizedModel.ShaderType.TRANSLUCENT_BRIGHT || shaderType == OptimizedModel.ShaderType.TRANSLUCENT_GLOWING;
+		writeDepthBuf = shaderType != OptimizedModel.ShaderType.TRANSLUCENT_GLOWING;
+		cutoutHack = shaderType == OptimizedModel.ShaderType.CUTOUT_GLOWING;
+		vertexAttributeState = new VertexAttributeState(color, shaderType == OptimizedModel.ShaderType.CUTOUT_BRIGHT || shaderType == OptimizedModel.ShaderType.TRANSLUCENT_BRIGHT ? 15 << 4 | 15 << 20 : null);
+	}
+
+	public void setupCompositeState() {
+	}
+
+	public Identifier getTexture() {
+		return texture;
+	}
+
+	public void setTexture(Identifier texture) {
+		this.texture = texture;
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+		if (!(object instanceof MaterialProperties)) {
+			return false;
+		}
+		final MaterialProperties that = (MaterialProperties) object;
+		return shaderType == that.shaderType && Objects.equals(texture, that.texture) && Objects.equals(vertexAttributeState, that.vertexAttributeState);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(texture, shaderType, vertexAttributeState);
+	}
+}

--- a/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/render/model/Mesh.java
+++ b/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/render/model/Mesh.java
@@ -1,0 +1,25 @@
+package org.mtr.mapping.render.model;
+
+import org.mtr.mapping.render.batch.MaterialProperties;
+import org.mtr.mapping.render.object.IndexBuffer;
+import org.mtr.mapping.render.object.VertexBuffer;
+
+import java.io.Closeable;
+
+public final class Mesh implements Closeable {
+	public final VertexBuffer vertexBuffer;
+	public final IndexBuffer indexBuffer;
+	public final MaterialProperties materialProperties;
+
+	public Mesh(VertexBuffer vertexBuffer, IndexBuffer indexBuffer, MaterialProperties materialProperties) {
+		this.vertexBuffer = vertexBuffer;
+		this.indexBuffer = indexBuffer;
+		this.materialProperties = materialProperties;
+	}
+
+	@Override
+	public void close() {
+		vertexBuffer.close();
+		indexBuffer.close();
+	}
+}

--- a/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/render/model/RawMesh.java
+++ b/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/render/model/RawMesh.java
@@ -1,0 +1,61 @@
+package org.mtr.mapping.render.model;
+
+import org.mtr.mapping.holder.Vector3f;
+import org.mtr.mapping.mapper.OptimizedModel;
+import org.mtr.mapping.render.batch.MaterialProperties;
+import org.mtr.mapping.render.object.IndexBuffer;
+import org.mtr.mapping.render.object.VertexBuffer;
+import org.mtr.mapping.render.vertex.Vertex;
+import org.mtr.mapping.render.vertex.VertexAttributeMapping;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class RawMesh {
+	public final MaterialProperties materialProperties;
+	public final List<Vertex> vertices = new ArrayList<>();
+
+	public RawMesh(MaterialProperties materialProperties) {
+		this.materialProperties = materialProperties;
+	}
+
+	public RawMesh(OptimizedModel.ShaderType shaderType, RawMesh rawMesh) {
+		materialProperties = new MaterialProperties(shaderType, rawMesh.materialProperties.getTexture(), rawMesh.materialProperties.vertexAttributeState.color);
+		vertices.addAll(rawMesh.vertices);
+	}
+
+	public void append(RawMesh nextMesh) {
+		vertices.addAll(nextMesh.vertices);
+	}
+
+	public void applyTranslation(float x, float y, float z) {
+	}
+
+	public void applyRotation(Vector3f axis, float angle) {
+	}
+
+	public void applyScale(float x, float y, float z) {
+	}
+
+	public void applyMirror(boolean vx, boolean vy, boolean vz, boolean nx, boolean ny, boolean nz) {
+	}
+
+	public void applyUVMirror(boolean u, boolean v) {
+	}
+
+	public void generateNormals() {
+	}
+
+	public void distinct() {
+	}
+
+	public void triangulate() {
+	}
+
+	public void validateVertexIndex() {
+	}
+
+	public Mesh upload(VertexAttributeMapping vertexAttributeMapping) {
+		return new Mesh(new VertexBuffer(), new IndexBuffer(0), materialProperties);
+	}
+}

--- a/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/render/obj/AtlasManager.java
+++ b/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/render/obj/AtlasManager.java
@@ -1,0 +1,12 @@
+package org.mtr.mapping.render.obj;
+
+import org.mtr.mapping.holder.Identifier;
+import org.mtr.mapping.render.model.RawMesh;
+
+public final class AtlasManager {
+	public void load(Identifier atlasConfiguration) {
+	}
+
+	public void applyToMesh(RawMesh mesh) {
+	}
+}

--- a/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
+++ b/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
@@ -1,0 +1,15 @@
+package org.mtr.mapping.render.obj;
+
+import org.mtr.mapping.holder.Identifier;
+import org.mtr.mapping.render.model.RawMesh;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+public final class ObjModelLoader {
+	public static Map<String, List<RawMesh>> loadModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, AtlasManager atlasManager, boolean splitModel) {
+		return Collections.emptyMap();
+	}
+}

--- a/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/render/object/IndexBuffer.java
+++ b/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/render/object/IndexBuffer.java
@@ -1,0 +1,23 @@
+package org.mtr.mapping.render.object;
+
+import java.io.Closeable;
+
+public final class IndexBuffer implements Closeable {
+	public final int indexType = 0;
+	private final int vertexCount;
+
+	public IndexBuffer(int vertexCount) {
+		this.vertexCount = vertexCount;
+	}
+
+	public void bind(int target) {
+	}
+
+	public int getVertexCount() {
+		return vertexCount;
+	}
+
+	@Override
+	public void close() {
+	}
+}

--- a/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/render/object/InstancedDrawHelper.java
+++ b/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/render/object/InstancedDrawHelper.java
@@ -1,0 +1,26 @@
+package org.mtr.mapping.render.object;
+
+import org.mtr.mapping.render.vertex.VertexAttributeMapping;
+import org.mtr.mapping.render.vertex.VertexAttributeType;
+
+import java.nio.ByteBuffer;
+
+public final class InstancedDrawHelper {
+
+	public static boolean setupInstanceAttributes(VertexArray vertexArray, VertexBuffer instanceBuffer, VertexAttributeMapping mapping, VertexAttributeType... vertexAttributeTypes) {
+		return true;
+	}
+
+	public static void setupInstanceAttributePointers(VertexBuffer instanceBuffer, VertexAttributeMapping mapping, int instanceOffsetBytes, VertexAttributeType... vertexAttributeTypes) {
+	}
+
+	public static void uploadInstances(VertexBuffer instanceBuffer, ByteBuffer byteBuffer, int size) {
+		instanceBuffer.upload(byteBuffer);
+	}
+
+	public static void drawElementsInstanced(VertexArray vertexArray, int instanceCount) {
+	}
+
+	private InstancedDrawHelper() {
+	}
+}

--- a/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/render/object/VertexArray.java
+++ b/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/render/object/VertexArray.java
@@ -1,0 +1,38 @@
+package org.mtr.mapping.render.object;
+
+import org.mtr.mapping.render.batch.MaterialProperties;
+import org.mtr.mapping.render.model.Mesh;
+import org.mtr.mapping.render.vertex.VertexAttributeMapping;
+
+import java.io.Closeable;
+
+public final class VertexArray implements Closeable {
+	public final MaterialProperties materialProperties;
+	public final IndexBuffer indexBuffer;
+	public final VertexAttributeMapping mapping;
+
+	public VertexArray(Mesh mesh, VertexAttributeMapping mapping) {
+		materialProperties = mesh.materialProperties;
+		indexBuffer = mesh.indexBuffer;
+		this.mapping = mapping;
+	}
+
+	public VertexArray(VertexArray other, MaterialProperties materialProperties) {
+		this.materialProperties = materialProperties;
+		indexBuffer = other.indexBuffer;
+		mapping = other.mapping;
+	}
+
+	public void bind() {
+	}
+
+	public static void unbind() {
+	}
+
+	public void draw() {
+	}
+
+	@Override
+	public void close() {
+	}
+}

--- a/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/render/object/VertexBuffer.java
+++ b/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/render/object/VertexBuffer.java
@@ -1,0 +1,16 @@
+package org.mtr.mapping.render.object;
+
+import java.io.Closeable;
+import java.nio.ByteBuffer;
+
+public final class VertexBuffer implements Closeable {
+	public void bind(int target) {
+	}
+
+	public void upload(ByteBuffer byteBuffer) {
+	}
+
+	@Override
+	public void close() {
+	}
+}

--- a/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/render/shader/ShaderManager.java
+++ b/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/render/shader/ShaderManager.java
@@ -12,4 +12,7 @@ public final class ShaderManager {
 
 	public void setupShaderBatchState(MaterialProperties materialProperties) {
 	}
+
+	public void cleanupShaderBatchState() {
+	}
 }

--- a/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/render/shader/ShaderManager.java
+++ b/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/render/shader/ShaderManager.java
@@ -1,0 +1,15 @@
+package org.mtr.mapping.render.shader;
+
+import org.mtr.mapping.render.batch.MaterialProperties;
+
+public final class ShaderManager {
+	public void reloadShaders() {
+	}
+
+	public boolean isReady() {
+		return false;
+	}
+
+	public void setupShaderBatchState(MaterialProperties materialProperties) {
+	}
+}

--- a/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/render/tool/GlStateTracker.java
+++ b/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/render/tool/GlStateTracker.java
@@ -1,0 +1,20 @@
+package org.mtr.mapping.render.tool;
+
+public final class GlStateTracker {
+	public static void capture() {
+	}
+
+	public static void restore() {
+	}
+
+	public static void assertProtected() {
+	}
+
+	public static boolean supportVertexAttributeDivisor() {
+		return false;
+	}
+
+	public static boolean isGl4ES() {
+		return false;
+	}
+}

--- a/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/render/tool/Utilities.java
+++ b/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/render/tool/Utilities.java
@@ -1,0 +1,39 @@
+package org.mtr.mapping.render.tool;
+
+import org.mtr.mapping.holder.Matrix4f;
+import org.mtr.mapping.holder.Vector3f;
+
+import java.nio.FloatBuffer;
+
+public final class Utilities {
+	public static int exchangeLightmapUVBits(int light) {
+		return (light >>> 16) | (((short) light) << 16);
+	}
+
+	public static Matrix4f create() {
+		return new Matrix4f();
+	}
+
+	public static Matrix4f copy(Matrix4f matrix4f) {
+		return matrix4f;
+	}
+
+	public static void store(Matrix4f matrix4f, FloatBuffer buffer) {
+	}
+
+	public static Vector3f transformPosition(Matrix4f matrix4f, Vector3f src) {
+		return src;
+	}
+
+	public static Vector3f transformDirection(Matrix4f matrix4f, Vector3f src) {
+		return src;
+	}
+
+	public static Vector3f copy(Vector3f vector3f) {
+		return vector3f;
+	}
+
+	public static boolean canUseCustomShader() {
+		return false;
+	}
+}

--- a/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/render/vertex/Vertex.java
+++ b/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/render/vertex/Vertex.java
@@ -1,0 +1,10 @@
+package org.mtr.mapping.render.vertex;
+
+import org.mtr.mapping.holder.Vector3f;
+
+public final class Vertex {
+	public Vector3f position;
+	public Vector3f normal;
+	public float u;
+	public float v;
+}

--- a/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/render/vertex/VertexAttributeMapping.java
+++ b/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/render/vertex/VertexAttributeMapping.java
@@ -1,0 +1,62 @@
+package org.mtr.mapping.render.vertex;
+
+import org.mtr.mapping.render.object.VertexBuffer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public final class VertexAttributeMapping {
+
+	public final Map<VertexAttributeType, VertexAttributeSource> sources;
+	public final Map<VertexAttributeType, Integer> pointers = new HashMap<>();
+	public final int strideVertex;
+	public final int strideInstance;
+	public final int paddingVertex;
+	public final int paddingInstance;
+
+	private VertexAttributeMapping(Map<VertexAttributeType, VertexAttributeSource> sources) {
+		this.sources = sources;
+		int strideVertex = 0;
+		int strideInstance = 0;
+		for (final VertexAttributeType vertexAttributeType : VertexAttributeType.values()) {
+			switch (sources.get(vertexAttributeType)) {
+				case VERTEX_BUFFER:
+					pointers.put(vertexAttributeType, strideVertex);
+					strideVertex += vertexAttributeType.byteSize;
+					break;
+				case INSTANCE_BUFFER:
+					pointers.put(vertexAttributeType, strideInstance);
+					strideInstance += vertexAttributeType.byteSize;
+					break;
+				default:
+					break;
+			}
+		}
+		this.strideVertex = strideVertex;
+		this.strideInstance = strideInstance;
+		paddingVertex = 0;
+		paddingInstance = 0;
+	}
+
+	public void setupAttributesToVao(VertexBuffer vertexBuffer) {
+	}
+
+	public static class Builder {
+		private final HashMap<VertexAttributeType, VertexAttributeSource> sources = new HashMap<>();
+
+		public Builder() {
+			for (final VertexAttributeType vertexAttributeType : VertexAttributeType.values()) {
+				sources.put(vertexAttributeType, VertexAttributeSource.VERTEX_BUFFER);
+			}
+		}
+
+		public Builder set(VertexAttributeType vertexAttributeType, VertexAttributeSource vertexAttributeSource) {
+			sources.put(vertexAttributeType, vertexAttributeSource);
+			return this;
+		}
+
+		public VertexAttributeMapping build() {
+			return new VertexAttributeMapping(sources);
+		}
+	}
+}

--- a/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/render/vertex/VertexAttributeSource.java
+++ b/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/render/vertex/VertexAttributeSource.java
@@ -1,0 +1,5 @@
+package org.mtr.mapping.render.vertex;
+
+public enum VertexAttributeSource {
+	GLOBAL, VERTEX_BUFFER, INSTANCE_BUFFER
+}

--- a/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/render/vertex/VertexAttributeState.java
+++ b/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/render/vertex/VertexAttributeState.java
@@ -1,0 +1,45 @@
+package org.mtr.mapping.render.vertex;
+
+import org.mtr.mapping.holder.Matrix4f;
+
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+public final class VertexAttributeState {
+
+	public final Integer color;
+	public final Integer lightmapUV;
+	public final Matrix4f matrix4f;
+
+	public VertexAttributeState(int color, int lightmapUV, Matrix4f matrix4f) {
+		this.color = color;
+		this.lightmapUV = lightmapUV;
+		this.matrix4f = matrix4f;
+	}
+
+	public VertexAttributeState(@Nullable Integer color, @Nullable Integer lightmapUV) {
+		this.color = color;
+		this.lightmapUV = lightmapUV;
+		matrix4f = null;
+	}
+
+	public void apply() {
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+		if (!(object instanceof VertexAttributeState)) {
+			return false;
+		}
+		final VertexAttributeState vertexAttributeState = (VertexAttributeState) object;
+		return Objects.equals(color, vertexAttributeState.color) && Objects.equals(lightmapUV, vertexAttributeState.lightmapUV) && Objects.equals(matrix4f, vertexAttributeState.matrix4f);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(color, lightmapUV, matrix4f);
+	}
+}

--- a/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/render/vertex/VertexAttributeType.java
+++ b/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/render/vertex/VertexAttributeType.java
@@ -1,0 +1,28 @@
+package org.mtr.mapping.render.vertex;
+
+public enum VertexAttributeType {
+	POSITION(0, 12),
+	COLOR(1, 4),
+	UV_TEXTURE(2, 8),
+	UV_OVERLAY(3, 4),
+	UV_LIGHTMAP(4, 4),
+	NORMAL(5, 3),
+	MATRIX_MODEL(6, 64);
+
+	public final int location;
+	public final int byteSize;
+
+	VertexAttributeType(int location, int byteSize) {
+		this.location = location;
+		this.byteSize = byteSize;
+	}
+
+	public void toggleAttributeArray(boolean enable) {
+	}
+
+	public void setupAttributePointer(int stride, int pointer) {
+	}
+
+	public void setAttributeDivisor(int divisor) {
+	}
+}

--- a/forge/1.17.1-mapping/src/main/java/org/mtr/mapping/mapper/GraphicsHolder.java
+++ b/forge/1.17.1-mapping/src/main/java/org/mtr/mapping/mapper/GraphicsHolder.java
@@ -127,6 +127,11 @@ public final class GraphicsHolder extends DummyClass {
 	}
 
 	@MappedMethod
+	public org.mtr.mapping.holder.Matrix4f copyPositionMatrix() {
+		return matrixStack == null ? new org.mtr.mapping.holder.Matrix4f() : new org.mtr.mapping.holder.Matrix4f(matrixStack.last().pose());
+	}
+
+	@MappedMethod
 	public void drawText(MutableText mutableText, int x, int y, int color, boolean shadow, int light) {
 		if (matrixStack != null) {
 			final MultiBufferSource.BufferSource immediate = MultiBufferSource.immediate(Tesselator.getInstance().getBuilder());

--- a/forge/1.17.1-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/forge/1.17.1-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -118,13 +118,10 @@ public final class OptimizedModel extends DummyClass {
 		private final RawModel rawModel = new RawModel();
 
 		private ObjModel(
-				List<RawMesh> rawMeshes, boolean flipTextureV,
+				List<RawMesh> rawMeshes,
 				float minX, float minY, float minZ,
 				float maxX, float maxY, float maxZ
 		) {
-			if (flipTextureV) {
-				rawMeshes.forEach(rawMesh -> rawMesh.applyUVMirror(false, true));
-			}
 			this.minX = minX;
 			this.minY = minY;
 			this.minZ = minZ;
@@ -142,9 +139,9 @@ public final class OptimizedModel extends DummyClass {
 
 			final Map<String, ObjModel> objModels = new HashMap<>();
 			ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel).forEach((key, rawMeshes) -> {
+				prepareRawMeshes(rawMeshes, flipTextureV);
 				final float[] bounds = {Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE};
 				rawMeshes.forEach(rawMesh -> {
-					rawMesh.applyRotation(new Vector3f(1, 0, 0), 180);
 					rawMesh.vertices.forEach(vertex -> {
 						final float x = vertex.position.getX();
 						final float y = vertex.position.getY();
@@ -157,10 +154,21 @@ public final class OptimizedModel extends DummyClass {
 						bounds[5] = Math.max(bounds[5], z);
 					});
 				});
-				objModels.put(key, new ObjModel(rawMeshes, flipTextureV, bounds[0], bounds[1], bounds[2], bounds[3], bounds[4], bounds[5]));
+				objModels.put(key, new ObjModel(rawMeshes, bounds[0], bounds[1], bounds[2], bounds[3], bounds[4], bounds[5]));
 			});
 
 			return objModels;
+		}
+
+		@MappedMethod
+		public static Map<String, List<RawMesh>> loadRawModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, @Nullable Identifier atlasIndex, boolean splitModel, boolean flipTextureV) {
+			if (atlasIndex != null) {
+				ATLAS_MANAGER.load(atlasIndex);
+			}
+
+			final Map<String, List<RawMesh>> rawModels = ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel);
+			rawModels.values().forEach(rawMeshes -> prepareRawMeshes(rawMeshes, flipTextureV));
+			return rawModels;
 		}
 
 		@MappedMethod
@@ -228,6 +236,15 @@ public final class OptimizedModel extends DummyClass {
 		public float getMaxZ() {
 			return maxZ;
 		}
+		private static void prepareRawMeshes(List<RawMesh> rawMeshes, boolean flipTextureV) {
+			rawMeshes.forEach(rawMesh -> {
+				rawMesh.applyRotation(new Vector3f(1, 0, 0), 180);
+				if (flipTextureV) {
+					rawMesh.applyUVMirror(false, true);
+				}
+			});
+		}
+
 	}
 
 	public enum ShaderType {

--- a/forge/1.17.1-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedRenderer.java
+++ b/forge/1.17.1-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedRenderer.java
@@ -10,20 +10,49 @@ import org.mtr.mapping.render.tool.Utilities;
 import org.mtr.mapping.render.vertex.VertexAttributeState;
 import org.mtr.mapping.tool.DummyClass;
 
+import java.util.function.Supplier;
+
 public final class OptimizedRenderer extends DummyClass {
 
 	private final BatchManager batchManager = new BatchManager();
 	private final ShaderManager shaderManager = new ShaderManager();
+	private int protectedDepth;
+	private int reloadDepth;
 
 	@MappedMethod
 	public void beginReload() {
-		shaderManager.reloadShaders();
-		GlStateTracker.capture();
+		if (reloadDepth++ == 0) {
+			shaderManager.reloadShaders();
+		}
+		beginProtectedState();
 	}
 
 	@MappedMethod
 	public void finishReload() {
-		GlStateTracker.restore();
+		if (reloadDepth > 0) {
+			reloadDepth--;
+			finishProtectedState();
+		}
+	}
+
+	@MappedMethod
+	public void runWithProtectedState(Runnable runnable) {
+		beginProtectedState();
+		try {
+			runnable.run();
+		} finally {
+			finishProtectedState();
+		}
+	}
+
+	@MappedMethod
+	public <T> T runWithProtectedState(Supplier<T> supplier) {
+		beginProtectedState();
+		try {
+			return supplier.get();
+		} finally {
+			finishProtectedState();
+		}
 	}
 
 	@MappedMethod
@@ -36,9 +65,7 @@ public final class OptimizedRenderer extends DummyClass {
 	@MappedMethod
 	public void render(boolean renderTranslucent) {
 		if (shaderManager.isReady()) {
-			GlStateTracker.capture();
-			batchManager.drawAll(shaderManager, renderTranslucent);
-			GlStateTracker.restore();
+			runWithProtectedState(() -> batchManager.drawAll(shaderManager, renderTranslucent));
 		}
 	}
 
@@ -53,5 +80,17 @@ public final class OptimizedRenderer extends DummyClass {
 	@MappedMethod
 	public static boolean hasOptimizedRendering() {
 		return true;
+	}
+
+	private void beginProtectedState() {
+		if (protectedDepth++ == 0) {
+			GlStateTracker.capture();
+		}
+	}
+
+	private void finishProtectedState() {
+		if (protectedDepth > 0 && --protectedDepth == 0) {
+			GlStateTracker.restore();
+		}
 	}
 }

--- a/forge/1.17.1-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
+++ b/forge/1.17.1-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
@@ -108,7 +108,9 @@ public final class ObjModelLoader {
 					mesh.faces.add(new Face(new int[]{face.getVertexIndex(0), face.getVertexIndex(1), face.getVertexIndex(2)}));
 				}
 
-				atlasManager.applyToMesh(mesh);
+				if (atlasManager != null) {
+					atlasManager.applyToMesh(mesh);
+				}
 				mesh.validateVertexIndex();
 				rawMeshes.add(mesh);
 			}

--- a/forge/1.17.1-mapping/src/main/java/org/mtr/mapping/render/object/InstancedDrawHelper.java
+++ b/forge/1.17.1-mapping/src/main/java/org/mtr/mapping/render/object/InstancedDrawHelper.java
@@ -1,0 +1,71 @@
+package org.mtr.mapping.render.object;
+
+import org.lwjgl.opengl.ARBInstancedArrays;
+import org.lwjgl.opengl.GL;
+import org.lwjgl.opengl.GL33;
+import org.mtr.mapping.render.vertex.VertexAttributeMapping;
+import org.mtr.mapping.render.vertex.VertexAttributeType;
+
+import java.nio.ByteBuffer;
+
+public final class InstancedDrawHelper {
+
+	public static boolean setupInstanceAttributes(VertexArray vertexArray, VertexBuffer instanceBuffer, VertexAttributeMapping mapping, VertexAttributeType... vertexAttributeTypes) {
+		vertexArray.bind();
+		instanceBuffer.bind(GL33.GL_ARRAY_BUFFER);
+		boolean supported = true;
+		for (final VertexAttributeType vertexAttributeType : vertexAttributeTypes) {
+			supported &= setupInstanceAttribute(mapping, vertexAttributeType);
+		}
+		VertexArray.unbind();
+		return supported;
+	}
+
+	public static void setupInstanceAttributePointers(VertexBuffer instanceBuffer, VertexAttributeMapping mapping, int instanceOffsetBytes, VertexAttributeType... vertexAttributeTypes) {
+		instanceBuffer.bind(GL33.GL_ARRAY_BUFFER);
+		for (final VertexAttributeType vertexAttributeType : vertexAttributeTypes) {
+			vertexAttributeType.setupAttributePointer(mapping.strideInstance, instanceOffsetBytes + mapping.pointers.get(vertexAttributeType));
+		}
+	}
+
+	public static void uploadInstances(VertexBuffer instanceBuffer, ByteBuffer byteBuffer, int size) {
+		instanceBuffer.bind(GL33.GL_ARRAY_BUFFER);
+		instanceBuffer.upload(byteBuffer, size, VertexBuffer.USAGE_STREAM_DRAW);
+	}
+
+	public static void drawElementsInstanced(VertexArray vertexArray, int instanceCount) {
+		GL33.glDrawElementsInstanced(GL33.GL_TRIANGLES, vertexArray.indexBuffer.getVertexCount(), vertexArray.indexBuffer.indexType, 0, instanceCount);
+	}
+
+	private static boolean setupInstanceAttribute(VertexAttributeMapping mapping, VertexAttributeType vertexAttributeType) {
+		vertexAttributeType.toggleAttributeArray(true);
+		vertexAttributeType.setupAttributePointer(mapping.strideInstance, mapping.pointers.get(vertexAttributeType));
+		return applyInstanceAttributeDivisor(vertexAttributeType);
+	}
+
+	private static boolean applyInstanceAttributeDivisor(VertexAttributeType vertexAttributeType) {
+		boolean supported = true;
+		for (int i = 0; i < vertexAttributeType.span; i++) {
+			supported &= applyInstanceAttributeDivisor(vertexAttributeType.location + i);
+		}
+		return supported;
+	}
+
+	private static boolean applyInstanceAttributeDivisor(int location) {
+		try {
+			final org.lwjgl.opengl.GLCapabilities capabilities = GL.getCapabilities();
+			if (capabilities.OpenGL33) {
+				GL33.glVertexAttribDivisor(location, 1);
+				return true;
+			} else if (capabilities.GL_ARB_instanced_arrays) {
+				ARBInstancedArrays.glVertexAttribDivisorARB(location, 1);
+				return true;
+			}
+		} catch (IllegalStateException ignored) {
+		}
+		return false;
+	}
+
+	private InstancedDrawHelper() {
+	}
+}

--- a/forge/1.17.1-mapping/src/main/java/org/mtr/mapping/render/shader/PatchingResourceProvider.java
+++ b/forge/1.17.1-mapping/src/main/java/org/mtr/mapping/render/shader/PatchingResourceProvider.java
@@ -40,9 +40,11 @@ public final class PatchingResourceProvider implements ResourceProvider {
 				inputStream.close();
 				dataObject.addProperty("vertex", dataObject.get("vertex").getAsString() + "_modelmat");
 				final JsonArray attributeArray = dataObject.get("attributes").getAsJsonArray();
-				for (int i = 0; i < 6 - attributeArray.size(); i++) {
-					attributeArray.add("Dummy" + i);
-				}
+				int dummyIndex = 0;
+					while (attributeArray.size() < 6) {
+						attributeArray.add("Dummy" + dummyIndex);
+						dummyIndex++;
+					}
 				attributeArray.add("ModelMat");
 				returningContent = dataObject.toString();
 			} else if (newIdentifier.getPath().endsWith(".vsh")) {

--- a/forge/1.17.1-mapping/src/main/java/org/mtr/mapping/render/tool/GlStateTracker.java
+++ b/forge/1.17.1-mapping/src/main/java/org/mtr/mapping/render/tool/GlStateTracker.java
@@ -12,9 +12,24 @@ public final class GlStateTracker {
 	private static boolean supportVertexAttributeDivisor;
 	private static boolean isGl4ES = false;
 
+	private static final int SHADER_TEXTURE_COUNT = 8;
+
 	private static int vertArrayBinding;
 	private static int arrayBufBinding;
 	private static int elementBufBinding;
+	private static int activeTexture;
+	private static final int[] shaderTextures = new int[SHADER_TEXTURE_COUNT];
+	private static boolean blendEnabled;
+	private static boolean depthTestEnabled;
+	private static boolean cullEnabled;
+	private static boolean depthMask;
+	private static int depthFunc;
+	private static int blendSrcRgb;
+	private static int blendDstRgb;
+	private static int blendSrcAlpha;
+	private static int blendDstAlpha;
+	private static int blendEquationRgb;
+	private static int blendEquationAlpha;
 	private static ShaderInstance currentShaderProgram;
 	private static boolean isStateProtected;
 
@@ -31,6 +46,21 @@ public final class GlStateTracker {
 		vertArrayBinding = GL33.glGetInteger(GL33.GL_VERTEX_ARRAY_BINDING);
 		arrayBufBinding = GL33.glGetInteger(GL33.GL_ARRAY_BUFFER_BINDING);
 		elementBufBinding = GL33.glGetInteger(GL33.GL_ELEMENT_ARRAY_BUFFER_BINDING);
+		activeTexture = GL33.glGetInteger(GL33.GL_ACTIVE_TEXTURE);
+		for (int i = 0; i < SHADER_TEXTURE_COUNT; i++) {
+			shaderTextures[i] = RenderSystem.getShaderTexture(i);
+		}
+		blendEnabled = GL33.glIsEnabled(GL33.GL_BLEND);
+		depthTestEnabled = GL33.glIsEnabled(GL33.GL_DEPTH_TEST);
+		cullEnabled = GL33.glIsEnabled(GL33.GL_CULL_FACE);
+		depthMask = GL33.glGetBoolean(GL33.GL_DEPTH_WRITEMASK);
+		depthFunc = GL33.glGetInteger(GL33.GL_DEPTH_FUNC);
+		blendSrcRgb = GL33.glGetInteger(GL33.GL_BLEND_SRC_RGB);
+		blendDstRgb = GL33.glGetInteger(GL33.GL_BLEND_DST_RGB);
+		blendSrcAlpha = GL33.glGetInteger(GL33.GL_BLEND_SRC_ALPHA);
+		blendDstAlpha = GL33.glGetInteger(GL33.GL_BLEND_DST_ALPHA);
+		blendEquationRgb = GL33.glGetInteger(GL33.GL_BLEND_EQUATION_RGB);
+		blendEquationAlpha = GL33.glGetInteger(GL33.GL_BLEND_EQUATION_ALPHA);
 		currentShaderProgram = RenderSystem.getShader();
 		isStateProtected = true;
 	}
@@ -46,12 +76,44 @@ public final class GlStateTracker {
 		GL33.glBindBuffer(GL33.GL_ELEMENT_ARRAY_BUFFER, elementBufBinding);
 
 		RenderSystem.setShader(() -> currentShaderProgram);
+		for (int i = 0; i < SHADER_TEXTURE_COUNT; i++) {
+			RenderSystem.setShaderTexture(i, shaderTextures[i]);
+		}
+		GL33.glActiveTexture(activeTexture);
 
-		// Obtain original state from RenderSystem?
-		RenderSystem.enableCull();
-		RenderSystem.depthMask(true);
+		setBlend(blendEnabled);
+		setDepthTest(depthTestEnabled);
+		setCull(cullEnabled);
+		RenderSystem.depthMask(depthMask);
+		RenderSystem.depthFunc(depthFunc);
+		GL33.glBlendFuncSeparate(blendSrcRgb, blendDstRgb, blendSrcAlpha, blendDstAlpha);
+		GL33.glBlendEquationSeparate(blendEquationRgb, blendEquationAlpha);
 
 		isStateProtected = false;
+	}
+
+	private static void setBlend(boolean enabled) {
+		if (enabled) {
+			RenderSystem.enableBlend();
+		} else {
+			RenderSystem.disableBlend();
+		}
+	}
+
+	private static void setDepthTest(boolean enabled) {
+		if (enabled) {
+			RenderSystem.enableDepthTest();
+		} else {
+			RenderSystem.disableDepthTest();
+		}
+	}
+
+	private static void setCull(boolean enabled) {
+		if (enabled) {
+			RenderSystem.enableCull();
+		} else {
+			RenderSystem.disableCull();
+		}
 	}
 
 	public static void assertProtected() {

--- a/forge/1.18.2-mapping/src/main/java/org/mtr/mapping/mapper/GraphicsHolder.java
+++ b/forge/1.18.2-mapping/src/main/java/org/mtr/mapping/mapper/GraphicsHolder.java
@@ -127,6 +127,11 @@ public final class GraphicsHolder extends DummyClass {
 	}
 
 	@MappedMethod
+	public org.mtr.mapping.holder.Matrix4f copyPositionMatrix() {
+		return matrixStack == null ? new org.mtr.mapping.holder.Matrix4f() : new org.mtr.mapping.holder.Matrix4f(matrixStack.last().pose());
+	}
+
+	@MappedMethod
 	public void drawText(MutableText mutableText, int x, int y, int color, boolean shadow, int light) {
 		if (matrixStack != null) {
 			final MultiBufferSource.BufferSource immediate = MultiBufferSource.immediate(Tesselator.getInstance().getBuilder());

--- a/forge/1.18.2-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/forge/1.18.2-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -118,13 +118,10 @@ public final class OptimizedModel extends DummyClass {
 		private final RawModel rawModel = new RawModel();
 
 		private ObjModel(
-				List<RawMesh> rawMeshes, boolean flipTextureV,
+				List<RawMesh> rawMeshes,
 				float minX, float minY, float minZ,
 				float maxX, float maxY, float maxZ
 		) {
-			if (flipTextureV) {
-				rawMeshes.forEach(rawMesh -> rawMesh.applyUVMirror(false, true));
-			}
 			this.minX = minX;
 			this.minY = minY;
 			this.minZ = minZ;
@@ -142,9 +139,9 @@ public final class OptimizedModel extends DummyClass {
 
 			final Map<String, ObjModel> objModels = new HashMap<>();
 			ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel).forEach((key, rawMeshes) -> {
+				prepareRawMeshes(rawMeshes, flipTextureV);
 				final float[] bounds = {Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE};
 				rawMeshes.forEach(rawMesh -> {
-					rawMesh.applyRotation(new Vector3f(1, 0, 0), 180);
 					rawMesh.vertices.forEach(vertex -> {
 						final float x = vertex.position.getX();
 						final float y = vertex.position.getY();
@@ -157,10 +154,21 @@ public final class OptimizedModel extends DummyClass {
 						bounds[5] = Math.max(bounds[5], z);
 					});
 				});
-				objModels.put(key, new ObjModel(rawMeshes, flipTextureV, bounds[0], bounds[1], bounds[2], bounds[3], bounds[4], bounds[5]));
+				objModels.put(key, new ObjModel(rawMeshes, bounds[0], bounds[1], bounds[2], bounds[3], bounds[4], bounds[5]));
 			});
 
 			return objModels;
+		}
+
+		@MappedMethod
+		public static Map<String, List<RawMesh>> loadRawModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, @Nullable Identifier atlasIndex, boolean splitModel, boolean flipTextureV) {
+			if (atlasIndex != null) {
+				ATLAS_MANAGER.load(atlasIndex);
+			}
+
+			final Map<String, List<RawMesh>> rawModels = ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel);
+			rawModels.values().forEach(rawMeshes -> prepareRawMeshes(rawMeshes, flipTextureV));
+			return rawModels;
 		}
 
 		@MappedMethod
@@ -228,6 +236,15 @@ public final class OptimizedModel extends DummyClass {
 		public float getMaxZ() {
 			return maxZ;
 		}
+		private static void prepareRawMeshes(List<RawMesh> rawMeshes, boolean flipTextureV) {
+			rawMeshes.forEach(rawMesh -> {
+				rawMesh.applyRotation(new Vector3f(1, 0, 0), 180);
+				if (flipTextureV) {
+					rawMesh.applyUVMirror(false, true);
+				}
+			});
+		}
+
 	}
 
 	public enum ShaderType {

--- a/forge/1.18.2-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedRenderer.java
+++ b/forge/1.18.2-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedRenderer.java
@@ -10,20 +10,49 @@ import org.mtr.mapping.render.tool.Utilities;
 import org.mtr.mapping.render.vertex.VertexAttributeState;
 import org.mtr.mapping.tool.DummyClass;
 
+import java.util.function.Supplier;
+
 public final class OptimizedRenderer extends DummyClass {
 
 	private final BatchManager batchManager = new BatchManager();
 	private final ShaderManager shaderManager = new ShaderManager();
+	private int protectedDepth;
+	private int reloadDepth;
 
 	@MappedMethod
 	public void beginReload() {
-		shaderManager.reloadShaders();
-		GlStateTracker.capture();
+		if (reloadDepth++ == 0) {
+			shaderManager.reloadShaders();
+		}
+		beginProtectedState();
 	}
 
 	@MappedMethod
 	public void finishReload() {
-		GlStateTracker.restore();
+		if (reloadDepth > 0) {
+			reloadDepth--;
+			finishProtectedState();
+		}
+	}
+
+	@MappedMethod
+	public void runWithProtectedState(Runnable runnable) {
+		beginProtectedState();
+		try {
+			runnable.run();
+		} finally {
+			finishProtectedState();
+		}
+	}
+
+	@MappedMethod
+	public <T> T runWithProtectedState(Supplier<T> supplier) {
+		beginProtectedState();
+		try {
+			return supplier.get();
+		} finally {
+			finishProtectedState();
+		}
 	}
 
 	@MappedMethod
@@ -36,9 +65,7 @@ public final class OptimizedRenderer extends DummyClass {
 	@MappedMethod
 	public void render(boolean renderTranslucent) {
 		if (shaderManager.isReady()) {
-			GlStateTracker.capture();
-			batchManager.drawAll(shaderManager, renderTranslucent);
-			GlStateTracker.restore();
+			runWithProtectedState(() -> batchManager.drawAll(shaderManager, renderTranslucent));
 		}
 	}
 
@@ -53,5 +80,17 @@ public final class OptimizedRenderer extends DummyClass {
 	@MappedMethod
 	public static boolean hasOptimizedRendering() {
 		return true;
+	}
+
+	private void beginProtectedState() {
+		if (protectedDepth++ == 0) {
+			GlStateTracker.capture();
+		}
+	}
+
+	private void finishProtectedState() {
+		if (protectedDepth > 0 && --protectedDepth == 0) {
+			GlStateTracker.restore();
+		}
 	}
 }

--- a/forge/1.18.2-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
+++ b/forge/1.18.2-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
@@ -108,7 +108,9 @@ public final class ObjModelLoader {
 					mesh.faces.add(new Face(new int[]{face.getVertexIndex(0), face.getVertexIndex(1), face.getVertexIndex(2)}));
 				}
 
-				atlasManager.applyToMesh(mesh);
+				if (atlasManager != null) {
+					atlasManager.applyToMesh(mesh);
+				}
 				mesh.validateVertexIndex();
 				rawMeshes.add(mesh);
 			}

--- a/forge/1.18.2-mapping/src/main/java/org/mtr/mapping/render/object/InstancedDrawHelper.java
+++ b/forge/1.18.2-mapping/src/main/java/org/mtr/mapping/render/object/InstancedDrawHelper.java
@@ -1,0 +1,71 @@
+package org.mtr.mapping.render.object;
+
+import org.lwjgl.opengl.ARBInstancedArrays;
+import org.lwjgl.opengl.GL;
+import org.lwjgl.opengl.GL33;
+import org.mtr.mapping.render.vertex.VertexAttributeMapping;
+import org.mtr.mapping.render.vertex.VertexAttributeType;
+
+import java.nio.ByteBuffer;
+
+public final class InstancedDrawHelper {
+
+	public static boolean setupInstanceAttributes(VertexArray vertexArray, VertexBuffer instanceBuffer, VertexAttributeMapping mapping, VertexAttributeType... vertexAttributeTypes) {
+		vertexArray.bind();
+		instanceBuffer.bind(GL33.GL_ARRAY_BUFFER);
+		boolean supported = true;
+		for (final VertexAttributeType vertexAttributeType : vertexAttributeTypes) {
+			supported &= setupInstanceAttribute(mapping, vertexAttributeType);
+		}
+		VertexArray.unbind();
+		return supported;
+	}
+
+	public static void setupInstanceAttributePointers(VertexBuffer instanceBuffer, VertexAttributeMapping mapping, int instanceOffsetBytes, VertexAttributeType... vertexAttributeTypes) {
+		instanceBuffer.bind(GL33.GL_ARRAY_BUFFER);
+		for (final VertexAttributeType vertexAttributeType : vertexAttributeTypes) {
+			vertexAttributeType.setupAttributePointer(mapping.strideInstance, instanceOffsetBytes + mapping.pointers.get(vertexAttributeType));
+		}
+	}
+
+	public static void uploadInstances(VertexBuffer instanceBuffer, ByteBuffer byteBuffer, int size) {
+		instanceBuffer.bind(GL33.GL_ARRAY_BUFFER);
+		instanceBuffer.upload(byteBuffer, size, VertexBuffer.USAGE_STREAM_DRAW);
+	}
+
+	public static void drawElementsInstanced(VertexArray vertexArray, int instanceCount) {
+		GL33.glDrawElementsInstanced(GL33.GL_TRIANGLES, vertexArray.indexBuffer.getVertexCount(), vertexArray.indexBuffer.indexType, 0, instanceCount);
+	}
+
+	private static boolean setupInstanceAttribute(VertexAttributeMapping mapping, VertexAttributeType vertexAttributeType) {
+		vertexAttributeType.toggleAttributeArray(true);
+		vertexAttributeType.setupAttributePointer(mapping.strideInstance, mapping.pointers.get(vertexAttributeType));
+		return applyInstanceAttributeDivisor(vertexAttributeType);
+	}
+
+	private static boolean applyInstanceAttributeDivisor(VertexAttributeType vertexAttributeType) {
+		boolean supported = true;
+		for (int i = 0; i < vertexAttributeType.span; i++) {
+			supported &= applyInstanceAttributeDivisor(vertexAttributeType.location + i);
+		}
+		return supported;
+	}
+
+	private static boolean applyInstanceAttributeDivisor(int location) {
+		try {
+			final org.lwjgl.opengl.GLCapabilities capabilities = GL.getCapabilities();
+			if (capabilities.OpenGL33) {
+				GL33.glVertexAttribDivisor(location, 1);
+				return true;
+			} else if (capabilities.GL_ARB_instanced_arrays) {
+				ARBInstancedArrays.glVertexAttribDivisorARB(location, 1);
+				return true;
+			}
+		} catch (IllegalStateException ignored) {
+		}
+		return false;
+	}
+
+	private InstancedDrawHelper() {
+	}
+}

--- a/forge/1.18.2-mapping/src/main/java/org/mtr/mapping/render/shader/PatchingResourceProvider.java
+++ b/forge/1.18.2-mapping/src/main/java/org/mtr/mapping/render/shader/PatchingResourceProvider.java
@@ -40,9 +40,11 @@ public final class PatchingResourceProvider implements ResourceProvider {
 				inputStream.close();
 				dataObject.addProperty("vertex", dataObject.get("vertex").getAsString() + "_modelmat");
 				final JsonArray attributeArray = dataObject.get("attributes").getAsJsonArray();
-				for (int i = 0; i < 6 - attributeArray.size(); i++) {
-					attributeArray.add("Dummy" + i);
-				}
+				int dummyIndex = 0;
+					while (attributeArray.size() < 6) {
+						attributeArray.add("Dummy" + dummyIndex);
+						dummyIndex++;
+					}
 				attributeArray.add("ModelMat");
 				returningContent = dataObject.toString();
 			} else if (newIdentifier.getPath().endsWith(".vsh")) {

--- a/forge/1.18.2-mapping/src/main/java/org/mtr/mapping/render/tool/GlStateTracker.java
+++ b/forge/1.18.2-mapping/src/main/java/org/mtr/mapping/render/tool/GlStateTracker.java
@@ -12,9 +12,24 @@ public final class GlStateTracker {
 	private static boolean supportVertexAttributeDivisor;
 	private static boolean isGl4ES = false;
 
+	private static final int SHADER_TEXTURE_COUNT = 8;
+
 	private static int vertArrayBinding;
 	private static int arrayBufBinding;
 	private static int elementBufBinding;
+	private static int activeTexture;
+	private static final int[] shaderTextures = new int[SHADER_TEXTURE_COUNT];
+	private static boolean blendEnabled;
+	private static boolean depthTestEnabled;
+	private static boolean cullEnabled;
+	private static boolean depthMask;
+	private static int depthFunc;
+	private static int blendSrcRgb;
+	private static int blendDstRgb;
+	private static int blendSrcAlpha;
+	private static int blendDstAlpha;
+	private static int blendEquationRgb;
+	private static int blendEquationAlpha;
 	private static ShaderInstance currentShaderProgram;
 	private static boolean isStateProtected;
 
@@ -31,6 +46,21 @@ public final class GlStateTracker {
 		vertArrayBinding = GL33.glGetInteger(GL33.GL_VERTEX_ARRAY_BINDING);
 		arrayBufBinding = GL33.glGetInteger(GL33.GL_ARRAY_BUFFER_BINDING);
 		elementBufBinding = GL33.glGetInteger(GL33.GL_ELEMENT_ARRAY_BUFFER_BINDING);
+		activeTexture = GL33.glGetInteger(GL33.GL_ACTIVE_TEXTURE);
+		for (int i = 0; i < SHADER_TEXTURE_COUNT; i++) {
+			shaderTextures[i] = RenderSystem.getShaderTexture(i);
+		}
+		blendEnabled = GL33.glIsEnabled(GL33.GL_BLEND);
+		depthTestEnabled = GL33.glIsEnabled(GL33.GL_DEPTH_TEST);
+		cullEnabled = GL33.glIsEnabled(GL33.GL_CULL_FACE);
+		depthMask = GL33.glGetBoolean(GL33.GL_DEPTH_WRITEMASK);
+		depthFunc = GL33.glGetInteger(GL33.GL_DEPTH_FUNC);
+		blendSrcRgb = GL33.glGetInteger(GL33.GL_BLEND_SRC_RGB);
+		blendDstRgb = GL33.glGetInteger(GL33.GL_BLEND_DST_RGB);
+		blendSrcAlpha = GL33.glGetInteger(GL33.GL_BLEND_SRC_ALPHA);
+		blendDstAlpha = GL33.glGetInteger(GL33.GL_BLEND_DST_ALPHA);
+		blendEquationRgb = GL33.glGetInteger(GL33.GL_BLEND_EQUATION_RGB);
+		blendEquationAlpha = GL33.glGetInteger(GL33.GL_BLEND_EQUATION_ALPHA);
 		currentShaderProgram = RenderSystem.getShader();
 		isStateProtected = true;
 	}
@@ -46,12 +76,44 @@ public final class GlStateTracker {
 		GL33.glBindBuffer(GL33.GL_ELEMENT_ARRAY_BUFFER, elementBufBinding);
 
 		RenderSystem.setShader(() -> currentShaderProgram);
+		for (int i = 0; i < SHADER_TEXTURE_COUNT; i++) {
+			RenderSystem.setShaderTexture(i, shaderTextures[i]);
+		}
+		GL33.glActiveTexture(activeTexture);
 
-		// Obtain original state from RenderSystem?
-		RenderSystem.enableCull();
-		RenderSystem.depthMask(true);
+		setBlend(blendEnabled);
+		setDepthTest(depthTestEnabled);
+		setCull(cullEnabled);
+		RenderSystem.depthMask(depthMask);
+		RenderSystem.depthFunc(depthFunc);
+		GL33.glBlendFuncSeparate(blendSrcRgb, blendDstRgb, blendSrcAlpha, blendDstAlpha);
+		GL33.glBlendEquationSeparate(blendEquationRgb, blendEquationAlpha);
 
 		isStateProtected = false;
+	}
+
+	private static void setBlend(boolean enabled) {
+		if (enabled) {
+			RenderSystem.enableBlend();
+		} else {
+			RenderSystem.disableBlend();
+		}
+	}
+
+	private static void setDepthTest(boolean enabled) {
+		if (enabled) {
+			RenderSystem.enableDepthTest();
+		} else {
+			RenderSystem.disableDepthTest();
+		}
+	}
+
+	private static void setCull(boolean enabled) {
+		if (enabled) {
+			RenderSystem.enableCull();
+		} else {
+			RenderSystem.disableCull();
+		}
 	}
 
 	public static void assertProtected() {

--- a/forge/1.19.2-mapping/src/main/java/org/mtr/mapping/mapper/GraphicsHolder.java
+++ b/forge/1.19.2-mapping/src/main/java/org/mtr/mapping/mapper/GraphicsHolder.java
@@ -127,6 +127,11 @@ public final class GraphicsHolder extends DummyClass {
 	}
 
 	@MappedMethod
+	public org.mtr.mapping.holder.Matrix4f copyPositionMatrix() {
+		return matrixStack == null ? new org.mtr.mapping.holder.Matrix4f() : new org.mtr.mapping.holder.Matrix4f(matrixStack.last().pose());
+	}
+
+	@MappedMethod
 	public void drawText(MutableText mutableText, int x, int y, int color, boolean shadow, int light) {
 		if (matrixStack != null) {
 			final MultiBufferSource.BufferSource immediate = MultiBufferSource.immediate(Tesselator.getInstance().getBuilder());

--- a/forge/1.19.2-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/forge/1.19.2-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -118,13 +118,10 @@ public final class OptimizedModel extends DummyClass {
 		private final RawModel rawModel = new RawModel();
 
 		private ObjModel(
-				List<RawMesh> rawMeshes, boolean flipTextureV,
+				List<RawMesh> rawMeshes,
 				float minX, float minY, float minZ,
 				float maxX, float maxY, float maxZ
 		) {
-			if (flipTextureV) {
-				rawMeshes.forEach(rawMesh -> rawMesh.applyUVMirror(false, true));
-			}
 			this.minX = minX;
 			this.minY = minY;
 			this.minZ = minZ;
@@ -142,9 +139,9 @@ public final class OptimizedModel extends DummyClass {
 
 			final Map<String, ObjModel> objModels = new HashMap<>();
 			ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel).forEach((key, rawMeshes) -> {
+				prepareRawMeshes(rawMeshes, flipTextureV);
 				final float[] bounds = {Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE};
 				rawMeshes.forEach(rawMesh -> {
-					rawMesh.applyRotation(new Vector3f(1, 0, 0), 180);
 					rawMesh.vertices.forEach(vertex -> {
 						final float x = vertex.position.getX();
 						final float y = vertex.position.getY();
@@ -157,10 +154,21 @@ public final class OptimizedModel extends DummyClass {
 						bounds[5] = Math.max(bounds[5], z);
 					});
 				});
-				objModels.put(key, new ObjModel(rawMeshes, flipTextureV, bounds[0], bounds[1], bounds[2], bounds[3], bounds[4], bounds[5]));
+				objModels.put(key, new ObjModel(rawMeshes, bounds[0], bounds[1], bounds[2], bounds[3], bounds[4], bounds[5]));
 			});
 
 			return objModels;
+		}
+
+		@MappedMethod
+		public static Map<String, List<RawMesh>> loadRawModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, @Nullable Identifier atlasIndex, boolean splitModel, boolean flipTextureV) {
+			if (atlasIndex != null) {
+				ATLAS_MANAGER.load(atlasIndex);
+			}
+
+			final Map<String, List<RawMesh>> rawModels = ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel);
+			rawModels.values().forEach(rawMeshes -> prepareRawMeshes(rawMeshes, flipTextureV));
+			return rawModels;
 		}
 
 		@MappedMethod
@@ -228,6 +236,15 @@ public final class OptimizedModel extends DummyClass {
 		public float getMaxZ() {
 			return maxZ;
 		}
+		private static void prepareRawMeshes(List<RawMesh> rawMeshes, boolean flipTextureV) {
+			rawMeshes.forEach(rawMesh -> {
+				rawMesh.applyRotation(new Vector3f(1, 0, 0), 180);
+				if (flipTextureV) {
+					rawMesh.applyUVMirror(false, true);
+				}
+			});
+		}
+
 	}
 
 	public enum ShaderType {

--- a/forge/1.19.2-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedRenderer.java
+++ b/forge/1.19.2-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedRenderer.java
@@ -10,20 +10,49 @@ import org.mtr.mapping.render.tool.Utilities;
 import org.mtr.mapping.render.vertex.VertexAttributeState;
 import org.mtr.mapping.tool.DummyClass;
 
+import java.util.function.Supplier;
+
 public final class OptimizedRenderer extends DummyClass {
 
 	private final BatchManager batchManager = new BatchManager();
 	private final ShaderManager shaderManager = new ShaderManager();
+	private int protectedDepth;
+	private int reloadDepth;
 
 	@MappedMethod
 	public void beginReload() {
-		shaderManager.reloadShaders();
-		GlStateTracker.capture();
+		if (reloadDepth++ == 0) {
+			shaderManager.reloadShaders();
+		}
+		beginProtectedState();
 	}
 
 	@MappedMethod
 	public void finishReload() {
-		GlStateTracker.restore();
+		if (reloadDepth > 0) {
+			reloadDepth--;
+			finishProtectedState();
+		}
+	}
+
+	@MappedMethod
+	public void runWithProtectedState(Runnable runnable) {
+		beginProtectedState();
+		try {
+			runnable.run();
+		} finally {
+			finishProtectedState();
+		}
+	}
+
+	@MappedMethod
+	public <T> T runWithProtectedState(Supplier<T> supplier) {
+		beginProtectedState();
+		try {
+			return supplier.get();
+		} finally {
+			finishProtectedState();
+		}
 	}
 
 	@MappedMethod
@@ -36,9 +65,7 @@ public final class OptimizedRenderer extends DummyClass {
 	@MappedMethod
 	public void render(boolean renderTranslucent) {
 		if (shaderManager.isReady()) {
-			GlStateTracker.capture();
-			batchManager.drawAll(shaderManager, renderTranslucent);
-			GlStateTracker.restore();
+			runWithProtectedState(() -> batchManager.drawAll(shaderManager, renderTranslucent));
 		}
 	}
 
@@ -53,5 +80,17 @@ public final class OptimizedRenderer extends DummyClass {
 	@MappedMethod
 	public static boolean hasOptimizedRendering() {
 		return true;
+	}
+
+	private void beginProtectedState() {
+		if (protectedDepth++ == 0) {
+			GlStateTracker.capture();
+		}
+	}
+
+	private void finishProtectedState() {
+		if (protectedDepth > 0 && --protectedDepth == 0) {
+			GlStateTracker.restore();
+		}
 	}
 }

--- a/forge/1.19.2-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
+++ b/forge/1.19.2-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
@@ -108,7 +108,9 @@ public final class ObjModelLoader {
 					mesh.faces.add(new Face(new int[]{face.getVertexIndex(0), face.getVertexIndex(1), face.getVertexIndex(2)}));
 				}
 
-				atlasManager.applyToMesh(mesh);
+				if (atlasManager != null) {
+					atlasManager.applyToMesh(mesh);
+				}
 				mesh.validateVertexIndex();
 				rawMeshes.add(mesh);
 			}

--- a/forge/1.19.2-mapping/src/main/java/org/mtr/mapping/render/object/InstancedDrawHelper.java
+++ b/forge/1.19.2-mapping/src/main/java/org/mtr/mapping/render/object/InstancedDrawHelper.java
@@ -1,0 +1,71 @@
+package org.mtr.mapping.render.object;
+
+import org.lwjgl.opengl.ARBInstancedArrays;
+import org.lwjgl.opengl.GL;
+import org.lwjgl.opengl.GL33;
+import org.mtr.mapping.render.vertex.VertexAttributeMapping;
+import org.mtr.mapping.render.vertex.VertexAttributeType;
+
+import java.nio.ByteBuffer;
+
+public final class InstancedDrawHelper {
+
+	public static boolean setupInstanceAttributes(VertexArray vertexArray, VertexBuffer instanceBuffer, VertexAttributeMapping mapping, VertexAttributeType... vertexAttributeTypes) {
+		vertexArray.bind();
+		instanceBuffer.bind(GL33.GL_ARRAY_BUFFER);
+		boolean supported = true;
+		for (final VertexAttributeType vertexAttributeType : vertexAttributeTypes) {
+			supported &= setupInstanceAttribute(mapping, vertexAttributeType);
+		}
+		VertexArray.unbind();
+		return supported;
+	}
+
+	public static void setupInstanceAttributePointers(VertexBuffer instanceBuffer, VertexAttributeMapping mapping, int instanceOffsetBytes, VertexAttributeType... vertexAttributeTypes) {
+		instanceBuffer.bind(GL33.GL_ARRAY_BUFFER);
+		for (final VertexAttributeType vertexAttributeType : vertexAttributeTypes) {
+			vertexAttributeType.setupAttributePointer(mapping.strideInstance, instanceOffsetBytes + mapping.pointers.get(vertexAttributeType));
+		}
+	}
+
+	public static void uploadInstances(VertexBuffer instanceBuffer, ByteBuffer byteBuffer, int size) {
+		instanceBuffer.bind(GL33.GL_ARRAY_BUFFER);
+		instanceBuffer.upload(byteBuffer, size, VertexBuffer.USAGE_STREAM_DRAW);
+	}
+
+	public static void drawElementsInstanced(VertexArray vertexArray, int instanceCount) {
+		GL33.glDrawElementsInstanced(GL33.GL_TRIANGLES, vertexArray.indexBuffer.getVertexCount(), vertexArray.indexBuffer.indexType, 0, instanceCount);
+	}
+
+	private static boolean setupInstanceAttribute(VertexAttributeMapping mapping, VertexAttributeType vertexAttributeType) {
+		vertexAttributeType.toggleAttributeArray(true);
+		vertexAttributeType.setupAttributePointer(mapping.strideInstance, mapping.pointers.get(vertexAttributeType));
+		return applyInstanceAttributeDivisor(vertexAttributeType);
+	}
+
+	private static boolean applyInstanceAttributeDivisor(VertexAttributeType vertexAttributeType) {
+		boolean supported = true;
+		for (int i = 0; i < vertexAttributeType.span; i++) {
+			supported &= applyInstanceAttributeDivisor(vertexAttributeType.location + i);
+		}
+		return supported;
+	}
+
+	private static boolean applyInstanceAttributeDivisor(int location) {
+		try {
+			final org.lwjgl.opengl.GLCapabilities capabilities = GL.getCapabilities();
+			if (capabilities.OpenGL33) {
+				GL33.glVertexAttribDivisor(location, 1);
+				return true;
+			} else if (capabilities.GL_ARB_instanced_arrays) {
+				ARBInstancedArrays.glVertexAttribDivisorARB(location, 1);
+				return true;
+			}
+		} catch (IllegalStateException ignored) {
+		}
+		return false;
+	}
+
+	private InstancedDrawHelper() {
+	}
+}

--- a/forge/1.19.2-mapping/src/main/java/org/mtr/mapping/render/shader/PatchingResourceProvider.java
+++ b/forge/1.19.2-mapping/src/main/java/org/mtr/mapping/render/shader/PatchingResourceProvider.java
@@ -41,8 +41,10 @@ public final class PatchingResourceProvider implements ResourceProvider {
 					inputStream.close();
 					dataObject.addProperty("vertex", dataObject.get("vertex").getAsString() + "_modelmat");
 					final JsonArray attributeArray = dataObject.get("attributes").getAsJsonArray();
-					for (int i = 0; i < 6 - attributeArray.size(); i++) {
-						attributeArray.add("Dummy" + i);
+					int dummyIndex = 0;
+					while (attributeArray.size() < 6) {
+						attributeArray.add("Dummy" + dummyIndex);
+						dummyIndex++;
 					}
 					attributeArray.add("ModelMat");
 					returningContent = dataObject.toString();

--- a/forge/1.19.2-mapping/src/main/java/org/mtr/mapping/render/tool/GlStateTracker.java
+++ b/forge/1.19.2-mapping/src/main/java/org/mtr/mapping/render/tool/GlStateTracker.java
@@ -12,9 +12,24 @@ public final class GlStateTracker {
 	private static boolean supportVertexAttributeDivisor;
 	private static boolean isGl4ES = false;
 
+	private static final int SHADER_TEXTURE_COUNT = 8;
+
 	private static int vertArrayBinding;
 	private static int arrayBufBinding;
 	private static int elementBufBinding;
+	private static int activeTexture;
+	private static final int[] shaderTextures = new int[SHADER_TEXTURE_COUNT];
+	private static boolean blendEnabled;
+	private static boolean depthTestEnabled;
+	private static boolean cullEnabled;
+	private static boolean depthMask;
+	private static int depthFunc;
+	private static int blendSrcRgb;
+	private static int blendDstRgb;
+	private static int blendSrcAlpha;
+	private static int blendDstAlpha;
+	private static int blendEquationRgb;
+	private static int blendEquationAlpha;
 	private static ShaderInstance currentShaderProgram;
 	private static boolean isStateProtected;
 
@@ -31,6 +46,21 @@ public final class GlStateTracker {
 		vertArrayBinding = GL33.glGetInteger(GL33.GL_VERTEX_ARRAY_BINDING);
 		arrayBufBinding = GL33.glGetInteger(GL33.GL_ARRAY_BUFFER_BINDING);
 		elementBufBinding = GL33.glGetInteger(GL33.GL_ELEMENT_ARRAY_BUFFER_BINDING);
+		activeTexture = GL33.glGetInteger(GL33.GL_ACTIVE_TEXTURE);
+		for (int i = 0; i < SHADER_TEXTURE_COUNT; i++) {
+			shaderTextures[i] = RenderSystem.getShaderTexture(i);
+		}
+		blendEnabled = GL33.glIsEnabled(GL33.GL_BLEND);
+		depthTestEnabled = GL33.glIsEnabled(GL33.GL_DEPTH_TEST);
+		cullEnabled = GL33.glIsEnabled(GL33.GL_CULL_FACE);
+		depthMask = GL33.glGetBoolean(GL33.GL_DEPTH_WRITEMASK);
+		depthFunc = GL33.glGetInteger(GL33.GL_DEPTH_FUNC);
+		blendSrcRgb = GL33.glGetInteger(GL33.GL_BLEND_SRC_RGB);
+		blendDstRgb = GL33.glGetInteger(GL33.GL_BLEND_DST_RGB);
+		blendSrcAlpha = GL33.glGetInteger(GL33.GL_BLEND_SRC_ALPHA);
+		blendDstAlpha = GL33.glGetInteger(GL33.GL_BLEND_DST_ALPHA);
+		blendEquationRgb = GL33.glGetInteger(GL33.GL_BLEND_EQUATION_RGB);
+		blendEquationAlpha = GL33.glGetInteger(GL33.GL_BLEND_EQUATION_ALPHA);
 		currentShaderProgram = RenderSystem.getShader();
 		isStateProtected = true;
 	}
@@ -46,12 +76,44 @@ public final class GlStateTracker {
 		GL33.glBindBuffer(GL33.GL_ELEMENT_ARRAY_BUFFER, elementBufBinding);
 
 		RenderSystem.setShader(() -> currentShaderProgram);
+		for (int i = 0; i < SHADER_TEXTURE_COUNT; i++) {
+			RenderSystem.setShaderTexture(i, shaderTextures[i]);
+		}
+		GL33.glActiveTexture(activeTexture);
 
-		// Obtain original state from RenderSystem?
-		RenderSystem.enableCull();
-		RenderSystem.depthMask(true);
+		setBlend(blendEnabled);
+		setDepthTest(depthTestEnabled);
+		setCull(cullEnabled);
+		RenderSystem.depthMask(depthMask);
+		RenderSystem.depthFunc(depthFunc);
+		GL33.glBlendFuncSeparate(blendSrcRgb, blendDstRgb, blendSrcAlpha, blendDstAlpha);
+		GL33.glBlendEquationSeparate(blendEquationRgb, blendEquationAlpha);
 
 		isStateProtected = false;
+	}
+
+	private static void setBlend(boolean enabled) {
+		if (enabled) {
+			RenderSystem.enableBlend();
+		} else {
+			RenderSystem.disableBlend();
+		}
+	}
+
+	private static void setDepthTest(boolean enabled) {
+		if (enabled) {
+			RenderSystem.enableDepthTest();
+		} else {
+			RenderSystem.disableDepthTest();
+		}
+	}
+
+	private static void setCull(boolean enabled) {
+		if (enabled) {
+			RenderSystem.enableCull();
+		} else {
+			RenderSystem.disableCull();
+		}
 	}
 
 	public static void assertProtected() {

--- a/forge/1.19.4-mapping/src/main/java/org/mtr/mapping/mapper/GraphicsHolder.java
+++ b/forge/1.19.4-mapping/src/main/java/org/mtr/mapping/mapper/GraphicsHolder.java
@@ -128,6 +128,11 @@ public final class GraphicsHolder extends DummyClass {
 	}
 
 	@MappedMethod
+	public org.mtr.mapping.holder.Matrix4f copyPositionMatrix() {
+		return matrixStack == null ? new org.mtr.mapping.holder.Matrix4f() : new org.mtr.mapping.holder.Matrix4f(matrixStack.last().pose());
+	}
+
+	@MappedMethod
 	public void drawText(MutableText mutableText, int x, int y, int color, boolean shadow, int light) {
 		if (matrixStack != null) {
 			final MultiBufferSource.BufferSource immediate = MultiBufferSource.immediate(Tesselator.getInstance().getBuilder());

--- a/forge/1.19.4-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/forge/1.19.4-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -119,13 +119,10 @@ public final class OptimizedModel extends DummyClass {
 		private final RawModel rawModel = new RawModel();
 
 		private ObjModel(
-				List<RawMesh> rawMeshes, boolean flipTextureV,
+				List<RawMesh> rawMeshes,
 				float minX, float minY, float minZ,
 				float maxX, float maxY, float maxZ
 		) {
-			if (flipTextureV) {
-				rawMeshes.forEach(rawMesh -> rawMesh.applyUVMirror(false, true));
-			}
 			this.minX = minX;
 			this.minY = minY;
 			this.minZ = minZ;
@@ -143,9 +140,9 @@ public final class OptimizedModel extends DummyClass {
 
 			final Map<String, ObjModel> objModels = new HashMap<>();
 			ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel).forEach((key, rawMeshes) -> {
+				prepareRawMeshes(rawMeshes, flipTextureV);
 				final float[] bounds = {Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE};
 				rawMeshes.forEach(rawMesh -> {
-					rawMesh.applyRotation(new Vector3f(1, 0, 0), 180);
 					rawMesh.vertices.forEach(vertex -> {
 						final float x = vertex.position.getX();
 						final float y = vertex.position.getY();
@@ -158,10 +155,21 @@ public final class OptimizedModel extends DummyClass {
 						bounds[5] = Math.max(bounds[5], z);
 					});
 				});
-				objModels.put(key, new ObjModel(rawMeshes, flipTextureV, bounds[0], bounds[1], bounds[2], bounds[3], bounds[4], bounds[5]));
+				objModels.put(key, new ObjModel(rawMeshes, bounds[0], bounds[1], bounds[2], bounds[3], bounds[4], bounds[5]));
 			});
 
 			return objModels;
+		}
+
+		@MappedMethod
+		public static Map<String, List<RawMesh>> loadRawModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, @Nullable Identifier atlasIndex, boolean splitModel, boolean flipTextureV) {
+			if (atlasIndex != null) {
+				ATLAS_MANAGER.load(atlasIndex);
+			}
+
+			final Map<String, List<RawMesh>> rawModels = ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel);
+			rawModels.values().forEach(rawMeshes -> prepareRawMeshes(rawMeshes, flipTextureV));
+			return rawModels;
 		}
 
 		@MappedMethod
@@ -229,6 +237,15 @@ public final class OptimizedModel extends DummyClass {
 		public float getMaxZ() {
 			return maxZ;
 		}
+		private static void prepareRawMeshes(List<RawMesh> rawMeshes, boolean flipTextureV) {
+			rawMeshes.forEach(rawMesh -> {
+				rawMesh.applyRotation(new Vector3f(1, 0, 0), 180);
+				if (flipTextureV) {
+					rawMesh.applyUVMirror(false, true);
+				}
+			});
+		}
+
 	}
 
 	public enum ShaderType {

--- a/forge/1.19.4-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedRenderer.java
+++ b/forge/1.19.4-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedRenderer.java
@@ -10,20 +10,49 @@ import org.mtr.mapping.render.tool.Utilities;
 import org.mtr.mapping.render.vertex.VertexAttributeState;
 import org.mtr.mapping.tool.DummyClass;
 
+import java.util.function.Supplier;
+
 public final class OptimizedRenderer extends DummyClass {
 
 	private final BatchManager batchManager = new BatchManager();
 	private final ShaderManager shaderManager = new ShaderManager();
+	private int protectedDepth;
+	private int reloadDepth;
 
 	@MappedMethod
 	public void beginReload() {
-		shaderManager.reloadShaders();
-		GlStateTracker.capture();
+		if (reloadDepth++ == 0) {
+			shaderManager.reloadShaders();
+		}
+		beginProtectedState();
 	}
 
 	@MappedMethod
 	public void finishReload() {
-		GlStateTracker.restore();
+		if (reloadDepth > 0) {
+			reloadDepth--;
+			finishProtectedState();
+		}
+	}
+
+	@MappedMethod
+	public void runWithProtectedState(Runnable runnable) {
+		beginProtectedState();
+		try {
+			runnable.run();
+		} finally {
+			finishProtectedState();
+		}
+	}
+
+	@MappedMethod
+	public <T> T runWithProtectedState(Supplier<T> supplier) {
+		beginProtectedState();
+		try {
+			return supplier.get();
+		} finally {
+			finishProtectedState();
+		}
 	}
 
 	@MappedMethod
@@ -36,9 +65,7 @@ public final class OptimizedRenderer extends DummyClass {
 	@MappedMethod
 	public void render(boolean renderTranslucent) {
 		if (shaderManager.isReady()) {
-			GlStateTracker.capture();
-			batchManager.drawAll(shaderManager, renderTranslucent);
-			GlStateTracker.restore();
+			runWithProtectedState(() -> batchManager.drawAll(shaderManager, renderTranslucent));
 		}
 	}
 
@@ -53,5 +80,17 @@ public final class OptimizedRenderer extends DummyClass {
 	@MappedMethod
 	public static boolean hasOptimizedRendering() {
 		return true;
+	}
+
+	private void beginProtectedState() {
+		if (protectedDepth++ == 0) {
+			GlStateTracker.capture();
+		}
+	}
+
+	private void finishProtectedState() {
+		if (protectedDepth > 0 && --protectedDepth == 0) {
+			GlStateTracker.restore();
+		}
 	}
 }

--- a/forge/1.19.4-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
+++ b/forge/1.19.4-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
@@ -108,7 +108,9 @@ public final class ObjModelLoader {
 					mesh.faces.add(new Face(new int[]{face.getVertexIndex(0), face.getVertexIndex(1), face.getVertexIndex(2)}));
 				}
 
-				atlasManager.applyToMesh(mesh);
+				if (atlasManager != null) {
+					atlasManager.applyToMesh(mesh);
+				}
 				mesh.validateVertexIndex();
 				rawMeshes.add(mesh);
 			}

--- a/forge/1.19.4-mapping/src/main/java/org/mtr/mapping/render/object/InstancedDrawHelper.java
+++ b/forge/1.19.4-mapping/src/main/java/org/mtr/mapping/render/object/InstancedDrawHelper.java
@@ -1,0 +1,71 @@
+package org.mtr.mapping.render.object;
+
+import org.lwjgl.opengl.ARBInstancedArrays;
+import org.lwjgl.opengl.GL;
+import org.lwjgl.opengl.GL33;
+import org.mtr.mapping.render.vertex.VertexAttributeMapping;
+import org.mtr.mapping.render.vertex.VertexAttributeType;
+
+import java.nio.ByteBuffer;
+
+public final class InstancedDrawHelper {
+
+	public static boolean setupInstanceAttributes(VertexArray vertexArray, VertexBuffer instanceBuffer, VertexAttributeMapping mapping, VertexAttributeType... vertexAttributeTypes) {
+		vertexArray.bind();
+		instanceBuffer.bind(GL33.GL_ARRAY_BUFFER);
+		boolean supported = true;
+		for (final VertexAttributeType vertexAttributeType : vertexAttributeTypes) {
+			supported &= setupInstanceAttribute(mapping, vertexAttributeType);
+		}
+		VertexArray.unbind();
+		return supported;
+	}
+
+	public static void setupInstanceAttributePointers(VertexBuffer instanceBuffer, VertexAttributeMapping mapping, int instanceOffsetBytes, VertexAttributeType... vertexAttributeTypes) {
+		instanceBuffer.bind(GL33.GL_ARRAY_BUFFER);
+		for (final VertexAttributeType vertexAttributeType : vertexAttributeTypes) {
+			vertexAttributeType.setupAttributePointer(mapping.strideInstance, instanceOffsetBytes + mapping.pointers.get(vertexAttributeType));
+		}
+	}
+
+	public static void uploadInstances(VertexBuffer instanceBuffer, ByteBuffer byteBuffer, int size) {
+		instanceBuffer.bind(GL33.GL_ARRAY_BUFFER);
+		instanceBuffer.upload(byteBuffer, size, VertexBuffer.USAGE_STREAM_DRAW);
+	}
+
+	public static void drawElementsInstanced(VertexArray vertexArray, int instanceCount) {
+		GL33.glDrawElementsInstanced(GL33.GL_TRIANGLES, vertexArray.indexBuffer.getVertexCount(), vertexArray.indexBuffer.indexType, 0, instanceCount);
+	}
+
+	private static boolean setupInstanceAttribute(VertexAttributeMapping mapping, VertexAttributeType vertexAttributeType) {
+		vertexAttributeType.toggleAttributeArray(true);
+		vertexAttributeType.setupAttributePointer(mapping.strideInstance, mapping.pointers.get(vertexAttributeType));
+		return applyInstanceAttributeDivisor(vertexAttributeType);
+	}
+
+	private static boolean applyInstanceAttributeDivisor(VertexAttributeType vertexAttributeType) {
+		boolean supported = true;
+		for (int i = 0; i < vertexAttributeType.span; i++) {
+			supported &= applyInstanceAttributeDivisor(vertexAttributeType.location + i);
+		}
+		return supported;
+	}
+
+	private static boolean applyInstanceAttributeDivisor(int location) {
+		try {
+			final org.lwjgl.opengl.GLCapabilities capabilities = GL.getCapabilities();
+			if (capabilities.OpenGL33) {
+				GL33.glVertexAttribDivisor(location, 1);
+				return true;
+			} else if (capabilities.GL_ARB_instanced_arrays) {
+				ARBInstancedArrays.glVertexAttribDivisorARB(location, 1);
+				return true;
+			}
+		} catch (IllegalStateException ignored) {
+		}
+		return false;
+	}
+
+	private InstancedDrawHelper() {
+	}
+}

--- a/forge/1.19.4-mapping/src/main/java/org/mtr/mapping/render/shader/PatchingResourceProvider.java
+++ b/forge/1.19.4-mapping/src/main/java/org/mtr/mapping/render/shader/PatchingResourceProvider.java
@@ -41,8 +41,10 @@ public final class PatchingResourceProvider implements ResourceProvider {
 					inputStream.close();
 					dataObject.addProperty("vertex", dataObject.get("vertex").getAsString() + "_modelmat");
 					final JsonArray attributeArray = dataObject.get("attributes").getAsJsonArray();
-					for (int i = 0; i < 6 - attributeArray.size(); i++) {
-						attributeArray.add("Dummy" + i);
+					int dummyIndex = 0;
+					while (attributeArray.size() < 6) {
+						attributeArray.add("Dummy" + dummyIndex);
+						dummyIndex++;
 					}
 					attributeArray.add("ModelMat");
 					returningContent = dataObject.toString();

--- a/forge/1.19.4-mapping/src/main/java/org/mtr/mapping/render/tool/GlStateTracker.java
+++ b/forge/1.19.4-mapping/src/main/java/org/mtr/mapping/render/tool/GlStateTracker.java
@@ -12,9 +12,24 @@ public final class GlStateTracker {
 	private static boolean supportVertexAttributeDivisor;
 	private static boolean isGl4ES = false;
 
+	private static final int SHADER_TEXTURE_COUNT = 8;
+
 	private static int vertArrayBinding;
 	private static int arrayBufBinding;
 	private static int elementBufBinding;
+	private static int activeTexture;
+	private static final int[] shaderTextures = new int[SHADER_TEXTURE_COUNT];
+	private static boolean blendEnabled;
+	private static boolean depthTestEnabled;
+	private static boolean cullEnabled;
+	private static boolean depthMask;
+	private static int depthFunc;
+	private static int blendSrcRgb;
+	private static int blendDstRgb;
+	private static int blendSrcAlpha;
+	private static int blendDstAlpha;
+	private static int blendEquationRgb;
+	private static int blendEquationAlpha;
 	private static ShaderInstance currentShaderProgram;
 	private static boolean isStateProtected;
 
@@ -31,6 +46,21 @@ public final class GlStateTracker {
 		vertArrayBinding = GL33.glGetInteger(GL33.GL_VERTEX_ARRAY_BINDING);
 		arrayBufBinding = GL33.glGetInteger(GL33.GL_ARRAY_BUFFER_BINDING);
 		elementBufBinding = GL33.glGetInteger(GL33.GL_ELEMENT_ARRAY_BUFFER_BINDING);
+		activeTexture = GL33.glGetInteger(GL33.GL_ACTIVE_TEXTURE);
+		for (int i = 0; i < SHADER_TEXTURE_COUNT; i++) {
+			shaderTextures[i] = RenderSystem.getShaderTexture(i);
+		}
+		blendEnabled = GL33.glIsEnabled(GL33.GL_BLEND);
+		depthTestEnabled = GL33.glIsEnabled(GL33.GL_DEPTH_TEST);
+		cullEnabled = GL33.glIsEnabled(GL33.GL_CULL_FACE);
+		depthMask = GL33.glGetBoolean(GL33.GL_DEPTH_WRITEMASK);
+		depthFunc = GL33.glGetInteger(GL33.GL_DEPTH_FUNC);
+		blendSrcRgb = GL33.glGetInteger(GL33.GL_BLEND_SRC_RGB);
+		blendDstRgb = GL33.glGetInteger(GL33.GL_BLEND_DST_RGB);
+		blendSrcAlpha = GL33.glGetInteger(GL33.GL_BLEND_SRC_ALPHA);
+		blendDstAlpha = GL33.glGetInteger(GL33.GL_BLEND_DST_ALPHA);
+		blendEquationRgb = GL33.glGetInteger(GL33.GL_BLEND_EQUATION_RGB);
+		blendEquationAlpha = GL33.glGetInteger(GL33.GL_BLEND_EQUATION_ALPHA);
 		currentShaderProgram = RenderSystem.getShader();
 		isStateProtected = true;
 	}
@@ -46,12 +76,44 @@ public final class GlStateTracker {
 		GL33.glBindBuffer(GL33.GL_ELEMENT_ARRAY_BUFFER, elementBufBinding);
 
 		RenderSystem.setShader(() -> currentShaderProgram);
+		for (int i = 0; i < SHADER_TEXTURE_COUNT; i++) {
+			RenderSystem.setShaderTexture(i, shaderTextures[i]);
+		}
+		GL33.glActiveTexture(activeTexture);
 
-		// Obtain original state from RenderSystem?
-		RenderSystem.enableCull();
-		RenderSystem.depthMask(true);
+		setBlend(blendEnabled);
+		setDepthTest(depthTestEnabled);
+		setCull(cullEnabled);
+		RenderSystem.depthMask(depthMask);
+		RenderSystem.depthFunc(depthFunc);
+		GL33.glBlendFuncSeparate(blendSrcRgb, blendDstRgb, blendSrcAlpha, blendDstAlpha);
+		GL33.glBlendEquationSeparate(blendEquationRgb, blendEquationAlpha);
 
 		isStateProtected = false;
+	}
+
+	private static void setBlend(boolean enabled) {
+		if (enabled) {
+			RenderSystem.enableBlend();
+		} else {
+			RenderSystem.disableBlend();
+		}
+	}
+
+	private static void setDepthTest(boolean enabled) {
+		if (enabled) {
+			RenderSystem.enableDepthTest();
+		} else {
+			RenderSystem.disableDepthTest();
+		}
+	}
+
+	private static void setCull(boolean enabled) {
+		if (enabled) {
+			RenderSystem.enableCull();
+		} else {
+			RenderSystem.disableCull();
+		}
 	}
 
 	public static void assertProtected() {

--- a/forge/1.20.1-mapping/src/main/java/org/mtr/mapping/mapper/GraphicsHolder.java
+++ b/forge/1.20.1-mapping/src/main/java/org/mtr/mapping/mapper/GraphicsHolder.java
@@ -144,6 +144,11 @@ public final class GraphicsHolder extends DummyClass {
 	}
 
 	@MappedMethod
+	public org.mtr.mapping.holder.Matrix4f copyPositionMatrix() {
+		return matrixStack == null ? new org.mtr.mapping.holder.Matrix4f() : new org.mtr.mapping.holder.Matrix4f(matrixStack.last().pose());
+	}
+
+	@MappedMethod
 	public void drawText(MutableText mutableText, int x, int y, int color, boolean shadow, int light) {
 		if (matrixStack != null) {
 			final MultiBufferSource.BufferSource immediate = drawContext == null ? MultiBufferSource.immediate(Tesselator.getInstance().getBuilder()) : drawContext.bufferSource();

--- a/forge/1.20.1-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/forge/1.20.1-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -119,13 +119,10 @@ public final class OptimizedModel extends DummyClass {
 		private final RawModel rawModel = new RawModel();
 
 		private ObjModel(
-				List<RawMesh> rawMeshes, boolean flipTextureV,
+				List<RawMesh> rawMeshes,
 				float minX, float minY, float minZ,
 				float maxX, float maxY, float maxZ
 		) {
-			if (flipTextureV) {
-				rawMeshes.forEach(rawMesh -> rawMesh.applyUVMirror(false, true));
-			}
 			this.minX = minX;
 			this.minY = minY;
 			this.minZ = minZ;
@@ -143,9 +140,9 @@ public final class OptimizedModel extends DummyClass {
 
 			final Map<String, ObjModel> objModels = new HashMap<>();
 			ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel).forEach((key, rawMeshes) -> {
+				prepareRawMeshes(rawMeshes, flipTextureV);
 				final float[] bounds = {Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE};
 				rawMeshes.forEach(rawMesh -> {
-					rawMesh.applyRotation(new Vector3f(1, 0, 0), 180);
 					rawMesh.vertices.forEach(vertex -> {
 						final float x = vertex.position.getX();
 						final float y = vertex.position.getY();
@@ -158,10 +155,21 @@ public final class OptimizedModel extends DummyClass {
 						bounds[5] = Math.max(bounds[5], z);
 					});
 				});
-				objModels.put(key, new ObjModel(rawMeshes, flipTextureV, bounds[0], bounds[1], bounds[2], bounds[3], bounds[4], bounds[5]));
+				objModels.put(key, new ObjModel(rawMeshes, bounds[0], bounds[1], bounds[2], bounds[3], bounds[4], bounds[5]));
 			});
 
 			return objModels;
+		}
+
+		@MappedMethod
+		public static Map<String, List<RawMesh>> loadRawModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, @Nullable Identifier atlasIndex, boolean splitModel, boolean flipTextureV) {
+			if (atlasIndex != null) {
+				ATLAS_MANAGER.load(atlasIndex);
+			}
+
+			final Map<String, List<RawMesh>> rawModels = ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel);
+			rawModels.values().forEach(rawMeshes -> prepareRawMeshes(rawMeshes, flipTextureV));
+			return rawModels;
 		}
 
 		@MappedMethod
@@ -229,6 +237,15 @@ public final class OptimizedModel extends DummyClass {
 		public float getMaxZ() {
 			return maxZ;
 		}
+		private static void prepareRawMeshes(List<RawMesh> rawMeshes, boolean flipTextureV) {
+			rawMeshes.forEach(rawMesh -> {
+				rawMesh.applyRotation(new Vector3f(1, 0, 0), 180);
+				if (flipTextureV) {
+					rawMesh.applyUVMirror(false, true);
+				}
+			});
+		}
+
 	}
 
 	public enum ShaderType {

--- a/forge/1.20.1-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedRenderer.java
+++ b/forge/1.20.1-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedRenderer.java
@@ -10,20 +10,49 @@ import org.mtr.mapping.render.tool.Utilities;
 import org.mtr.mapping.render.vertex.VertexAttributeState;
 import org.mtr.mapping.tool.DummyClass;
 
+import java.util.function.Supplier;
+
 public final class OptimizedRenderer extends DummyClass {
 
 	private final BatchManager batchManager = new BatchManager();
 	private final ShaderManager shaderManager = new ShaderManager();
+	private int protectedDepth;
+	private int reloadDepth;
 
 	@MappedMethod
 	public void beginReload() {
-		shaderManager.reloadShaders();
-		GlStateTracker.capture();
+		if (reloadDepth++ == 0) {
+			shaderManager.reloadShaders();
+		}
+		beginProtectedState();
 	}
 
 	@MappedMethod
 	public void finishReload() {
-		GlStateTracker.restore();
+		if (reloadDepth > 0) {
+			reloadDepth--;
+			finishProtectedState();
+		}
+	}
+
+	@MappedMethod
+	public void runWithProtectedState(Runnable runnable) {
+		beginProtectedState();
+		try {
+			runnable.run();
+		} finally {
+			finishProtectedState();
+		}
+	}
+
+	@MappedMethod
+	public <T> T runWithProtectedState(Supplier<T> supplier) {
+		beginProtectedState();
+		try {
+			return supplier.get();
+		} finally {
+			finishProtectedState();
+		}
 	}
 
 	@MappedMethod
@@ -36,9 +65,7 @@ public final class OptimizedRenderer extends DummyClass {
 	@MappedMethod
 	public void render(boolean renderTranslucent) {
 		if (shaderManager.isReady()) {
-			GlStateTracker.capture();
-			batchManager.drawAll(shaderManager, renderTranslucent);
-			GlStateTracker.restore();
+			runWithProtectedState(() -> batchManager.drawAll(shaderManager, renderTranslucent));
 		}
 	}
 
@@ -53,5 +80,17 @@ public final class OptimizedRenderer extends DummyClass {
 	@MappedMethod
 	public static boolean hasOptimizedRendering() {
 		return true;
+	}
+
+	private void beginProtectedState() {
+		if (protectedDepth++ == 0) {
+			GlStateTracker.capture();
+		}
+	}
+
+	private void finishProtectedState() {
+		if (protectedDepth > 0 && --protectedDepth == 0) {
+			GlStateTracker.restore();
+		}
 	}
 }

--- a/forge/1.20.1-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
+++ b/forge/1.20.1-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
@@ -108,7 +108,9 @@ public final class ObjModelLoader {
 					mesh.faces.add(new Face(new int[]{face.getVertexIndex(0), face.getVertexIndex(1), face.getVertexIndex(2)}));
 				}
 
-				atlasManager.applyToMesh(mesh);
+				if (atlasManager != null) {
+					atlasManager.applyToMesh(mesh);
+				}
 				mesh.validateVertexIndex();
 				rawMeshes.add(mesh);
 			}

--- a/forge/1.20.1-mapping/src/main/java/org/mtr/mapping/render/object/InstancedDrawHelper.java
+++ b/forge/1.20.1-mapping/src/main/java/org/mtr/mapping/render/object/InstancedDrawHelper.java
@@ -1,0 +1,71 @@
+package org.mtr.mapping.render.object;
+
+import org.lwjgl.opengl.ARBInstancedArrays;
+import org.lwjgl.opengl.GL;
+import org.lwjgl.opengl.GL33;
+import org.mtr.mapping.render.vertex.VertexAttributeMapping;
+import org.mtr.mapping.render.vertex.VertexAttributeType;
+
+import java.nio.ByteBuffer;
+
+public final class InstancedDrawHelper {
+
+	public static boolean setupInstanceAttributes(VertexArray vertexArray, VertexBuffer instanceBuffer, VertexAttributeMapping mapping, VertexAttributeType... vertexAttributeTypes) {
+		vertexArray.bind();
+		instanceBuffer.bind(GL33.GL_ARRAY_BUFFER);
+		boolean supported = true;
+		for (final VertexAttributeType vertexAttributeType : vertexAttributeTypes) {
+			supported &= setupInstanceAttribute(mapping, vertexAttributeType);
+		}
+		VertexArray.unbind();
+		return supported;
+	}
+
+	public static void setupInstanceAttributePointers(VertexBuffer instanceBuffer, VertexAttributeMapping mapping, int instanceOffsetBytes, VertexAttributeType... vertexAttributeTypes) {
+		instanceBuffer.bind(GL33.GL_ARRAY_BUFFER);
+		for (final VertexAttributeType vertexAttributeType : vertexAttributeTypes) {
+			vertexAttributeType.setupAttributePointer(mapping.strideInstance, instanceOffsetBytes + mapping.pointers.get(vertexAttributeType));
+		}
+	}
+
+	public static void uploadInstances(VertexBuffer instanceBuffer, ByteBuffer byteBuffer, int size) {
+		instanceBuffer.bind(GL33.GL_ARRAY_BUFFER);
+		instanceBuffer.upload(byteBuffer, size, VertexBuffer.USAGE_STREAM_DRAW);
+	}
+
+	public static void drawElementsInstanced(VertexArray vertexArray, int instanceCount) {
+		GL33.glDrawElementsInstanced(GL33.GL_TRIANGLES, vertexArray.indexBuffer.getVertexCount(), vertexArray.indexBuffer.indexType, 0, instanceCount);
+	}
+
+	private static boolean setupInstanceAttribute(VertexAttributeMapping mapping, VertexAttributeType vertexAttributeType) {
+		vertexAttributeType.toggleAttributeArray(true);
+		vertexAttributeType.setupAttributePointer(mapping.strideInstance, mapping.pointers.get(vertexAttributeType));
+		return applyInstanceAttributeDivisor(vertexAttributeType);
+	}
+
+	private static boolean applyInstanceAttributeDivisor(VertexAttributeType vertexAttributeType) {
+		boolean supported = true;
+		for (int i = 0; i < vertexAttributeType.span; i++) {
+			supported &= applyInstanceAttributeDivisor(vertexAttributeType.location + i);
+		}
+		return supported;
+	}
+
+	private static boolean applyInstanceAttributeDivisor(int location) {
+		try {
+			final org.lwjgl.opengl.GLCapabilities capabilities = GL.getCapabilities();
+			if (capabilities.OpenGL33) {
+				GL33.glVertexAttribDivisor(location, 1);
+				return true;
+			} else if (capabilities.GL_ARB_instanced_arrays) {
+				ARBInstancedArrays.glVertexAttribDivisorARB(location, 1);
+				return true;
+			}
+		} catch (IllegalStateException ignored) {
+		}
+		return false;
+	}
+
+	private InstancedDrawHelper() {
+	}
+}

--- a/forge/1.20.1-mapping/src/main/java/org/mtr/mapping/render/shader/PatchingResourceProvider.java
+++ b/forge/1.20.1-mapping/src/main/java/org/mtr/mapping/render/shader/PatchingResourceProvider.java
@@ -41,8 +41,10 @@ public final class PatchingResourceProvider implements ResourceProvider {
 					inputStream.close();
 					dataObject.addProperty("vertex", dataObject.get("vertex").getAsString() + "_modelmat");
 					final JsonArray attributeArray = dataObject.get("attributes").getAsJsonArray();
-					for (int i = 0; i < 6 - attributeArray.size(); i++) {
-						attributeArray.add("Dummy" + i);
+					int dummyIndex = 0;
+					while (attributeArray.size() < 6) {
+						attributeArray.add("Dummy" + dummyIndex);
+						dummyIndex++;
 					}
 					attributeArray.add("ModelMat");
 					returningContent = dataObject.toString();

--- a/forge/1.20.1-mapping/src/main/java/org/mtr/mapping/render/tool/GlStateTracker.java
+++ b/forge/1.20.1-mapping/src/main/java/org/mtr/mapping/render/tool/GlStateTracker.java
@@ -12,9 +12,24 @@ public final class GlStateTracker {
 	private static boolean supportVertexAttributeDivisor;
 	private static boolean isGl4ES = false;
 
+	private static final int SHADER_TEXTURE_COUNT = 8;
+
 	private static int vertArrayBinding;
 	private static int arrayBufBinding;
 	private static int elementBufBinding;
+	private static int activeTexture;
+	private static final int[] shaderTextures = new int[SHADER_TEXTURE_COUNT];
+	private static boolean blendEnabled;
+	private static boolean depthTestEnabled;
+	private static boolean cullEnabled;
+	private static boolean depthMask;
+	private static int depthFunc;
+	private static int blendSrcRgb;
+	private static int blendDstRgb;
+	private static int blendSrcAlpha;
+	private static int blendDstAlpha;
+	private static int blendEquationRgb;
+	private static int blendEquationAlpha;
 	private static ShaderInstance currentShaderProgram;
 	private static boolean isStateProtected;
 
@@ -31,6 +46,21 @@ public final class GlStateTracker {
 		vertArrayBinding = GL33.glGetInteger(GL33.GL_VERTEX_ARRAY_BINDING);
 		arrayBufBinding = GL33.glGetInteger(GL33.GL_ARRAY_BUFFER_BINDING);
 		elementBufBinding = GL33.glGetInteger(GL33.GL_ELEMENT_ARRAY_BUFFER_BINDING);
+		activeTexture = GL33.glGetInteger(GL33.GL_ACTIVE_TEXTURE);
+		for (int i = 0; i < SHADER_TEXTURE_COUNT; i++) {
+			shaderTextures[i] = RenderSystem.getShaderTexture(i);
+		}
+		blendEnabled = GL33.glIsEnabled(GL33.GL_BLEND);
+		depthTestEnabled = GL33.glIsEnabled(GL33.GL_DEPTH_TEST);
+		cullEnabled = GL33.glIsEnabled(GL33.GL_CULL_FACE);
+		depthMask = GL33.glGetBoolean(GL33.GL_DEPTH_WRITEMASK);
+		depthFunc = GL33.glGetInteger(GL33.GL_DEPTH_FUNC);
+		blendSrcRgb = GL33.glGetInteger(GL33.GL_BLEND_SRC_RGB);
+		blendDstRgb = GL33.glGetInteger(GL33.GL_BLEND_DST_RGB);
+		blendSrcAlpha = GL33.glGetInteger(GL33.GL_BLEND_SRC_ALPHA);
+		blendDstAlpha = GL33.glGetInteger(GL33.GL_BLEND_DST_ALPHA);
+		blendEquationRgb = GL33.glGetInteger(GL33.GL_BLEND_EQUATION_RGB);
+		blendEquationAlpha = GL33.glGetInteger(GL33.GL_BLEND_EQUATION_ALPHA);
 		currentShaderProgram = RenderSystem.getShader();
 		isStateProtected = true;
 	}
@@ -46,12 +76,44 @@ public final class GlStateTracker {
 		GL33.glBindBuffer(GL33.GL_ELEMENT_ARRAY_BUFFER, elementBufBinding);
 
 		RenderSystem.setShader(() -> currentShaderProgram);
+		for (int i = 0; i < SHADER_TEXTURE_COUNT; i++) {
+			RenderSystem.setShaderTexture(i, shaderTextures[i]);
+		}
+		GL33.glActiveTexture(activeTexture);
 
-		// Obtain original state from RenderSystem?
-		RenderSystem.enableCull();
-		RenderSystem.depthMask(true);
+		setBlend(blendEnabled);
+		setDepthTest(depthTestEnabled);
+		setCull(cullEnabled);
+		RenderSystem.depthMask(depthMask);
+		RenderSystem.depthFunc(depthFunc);
+		GL33.glBlendFuncSeparate(blendSrcRgb, blendDstRgb, blendSrcAlpha, blendDstAlpha);
+		GL33.glBlendEquationSeparate(blendEquationRgb, blendEquationAlpha);
 
 		isStateProtected = false;
+	}
+
+	private static void setBlend(boolean enabled) {
+		if (enabled) {
+			RenderSystem.enableBlend();
+		} else {
+			RenderSystem.disableBlend();
+		}
+	}
+
+	private static void setDepthTest(boolean enabled) {
+		if (enabled) {
+			RenderSystem.enableDepthTest();
+		} else {
+			RenderSystem.disableDepthTest();
+		}
+	}
+
+	private static void setCull(boolean enabled) {
+		if (enabled) {
+			RenderSystem.enableCull();
+		} else {
+			RenderSystem.disableCull();
+		}
 	}
 
 	public static void assertProtected() {

--- a/forge/1.20.4-mapping/src/main/java/org/mtr/mapping/mapper/GraphicsHolder.java
+++ b/forge/1.20.4-mapping/src/main/java/org/mtr/mapping/mapper/GraphicsHolder.java
@@ -144,6 +144,11 @@ public final class GraphicsHolder extends DummyClass {
 	}
 
 	@MappedMethod
+	public org.mtr.mapping.holder.Matrix4f copyPositionMatrix() {
+		return matrixStack == null ? new org.mtr.mapping.holder.Matrix4f() : new org.mtr.mapping.holder.Matrix4f(matrixStack.last().pose());
+	}
+
+	@MappedMethod
 	public void drawText(MutableText mutableText, int x, int y, int color, boolean shadow, int light) {
 		if (matrixStack != null) {
 			final MultiBufferSource.BufferSource immediate = drawContext == null ? MultiBufferSource.immediate(Tesselator.getInstance().getBuilder()) : drawContext.bufferSource();

--- a/forge/1.20.4-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/forge/1.20.4-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -119,13 +119,10 @@ public final class OptimizedModel extends DummyClass {
 		private final RawModel rawModel = new RawModel();
 
 		private ObjModel(
-				List<RawMesh> rawMeshes, boolean flipTextureV,
+				List<RawMesh> rawMeshes,
 				float minX, float minY, float minZ,
 				float maxX, float maxY, float maxZ
 		) {
-			if (flipTextureV) {
-				rawMeshes.forEach(rawMesh -> rawMesh.applyUVMirror(false, true));
-			}
 			this.minX = minX;
 			this.minY = minY;
 			this.minZ = minZ;
@@ -143,9 +140,9 @@ public final class OptimizedModel extends DummyClass {
 
 			final Map<String, ObjModel> objModels = new HashMap<>();
 			ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel).forEach((key, rawMeshes) -> {
+				prepareRawMeshes(rawMeshes, flipTextureV);
 				final float[] bounds = {Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE};
 				rawMeshes.forEach(rawMesh -> {
-					rawMesh.applyRotation(new Vector3f(1, 0, 0), 180);
 					rawMesh.vertices.forEach(vertex -> {
 						final float x = vertex.position.getX();
 						final float y = vertex.position.getY();
@@ -158,10 +155,21 @@ public final class OptimizedModel extends DummyClass {
 						bounds[5] = Math.max(bounds[5], z);
 					});
 				});
-				objModels.put(key, new ObjModel(rawMeshes, flipTextureV, bounds[0], bounds[1], bounds[2], bounds[3], bounds[4], bounds[5]));
+				objModels.put(key, new ObjModel(rawMeshes, bounds[0], bounds[1], bounds[2], bounds[3], bounds[4], bounds[5]));
 			});
 
 			return objModels;
+		}
+
+		@MappedMethod
+		public static Map<String, List<RawMesh>> loadRawModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, @Nullable Identifier atlasIndex, boolean splitModel, boolean flipTextureV) {
+			if (atlasIndex != null) {
+				ATLAS_MANAGER.load(atlasIndex);
+			}
+
+			final Map<String, List<RawMesh>> rawModels = ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel);
+			rawModels.values().forEach(rawMeshes -> prepareRawMeshes(rawMeshes, flipTextureV));
+			return rawModels;
 		}
 
 		@MappedMethod
@@ -229,6 +237,15 @@ public final class OptimizedModel extends DummyClass {
 		public float getMaxZ() {
 			return maxZ;
 		}
+		private static void prepareRawMeshes(List<RawMesh> rawMeshes, boolean flipTextureV) {
+			rawMeshes.forEach(rawMesh -> {
+				rawMesh.applyRotation(new Vector3f(1, 0, 0), 180);
+				if (flipTextureV) {
+					rawMesh.applyUVMirror(false, true);
+				}
+			});
+		}
+
 	}
 
 	public enum ShaderType {

--- a/forge/1.20.4-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedRenderer.java
+++ b/forge/1.20.4-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedRenderer.java
@@ -10,20 +10,49 @@ import org.mtr.mapping.render.tool.Utilities;
 import org.mtr.mapping.render.vertex.VertexAttributeState;
 import org.mtr.mapping.tool.DummyClass;
 
+import java.util.function.Supplier;
+
 public final class OptimizedRenderer extends DummyClass {
 
 	private final BatchManager batchManager = new BatchManager();
 	private final ShaderManager shaderManager = new ShaderManager();
+	private int protectedDepth;
+	private int reloadDepth;
 
 	@MappedMethod
 	public void beginReload() {
-		shaderManager.reloadShaders();
-		GlStateTracker.capture();
+		if (reloadDepth++ == 0) {
+			shaderManager.reloadShaders();
+		}
+		beginProtectedState();
 	}
 
 	@MappedMethod
 	public void finishReload() {
-		GlStateTracker.restore();
+		if (reloadDepth > 0) {
+			reloadDepth--;
+			finishProtectedState();
+		}
+	}
+
+	@MappedMethod
+	public void runWithProtectedState(Runnable runnable) {
+		beginProtectedState();
+		try {
+			runnable.run();
+		} finally {
+			finishProtectedState();
+		}
+	}
+
+	@MappedMethod
+	public <T> T runWithProtectedState(Supplier<T> supplier) {
+		beginProtectedState();
+		try {
+			return supplier.get();
+		} finally {
+			finishProtectedState();
+		}
 	}
 
 	@MappedMethod
@@ -36,9 +65,7 @@ public final class OptimizedRenderer extends DummyClass {
 	@MappedMethod
 	public void render(boolean renderTranslucent) {
 		if (shaderManager.isReady()) {
-			GlStateTracker.capture();
-			batchManager.drawAll(shaderManager, renderTranslucent);
-			GlStateTracker.restore();
+			runWithProtectedState(() -> batchManager.drawAll(shaderManager, renderTranslucent));
 		}
 	}
 
@@ -53,5 +80,17 @@ public final class OptimizedRenderer extends DummyClass {
 	@MappedMethod
 	public static boolean hasOptimizedRendering() {
 		return true;
+	}
+
+	private void beginProtectedState() {
+		if (protectedDepth++ == 0) {
+			GlStateTracker.capture();
+		}
+	}
+
+	private void finishProtectedState() {
+		if (protectedDepth > 0 && --protectedDepth == 0) {
+			GlStateTracker.restore();
+		}
 	}
 }

--- a/forge/1.20.4-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
+++ b/forge/1.20.4-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
@@ -50,7 +50,11 @@ public final class ObjModelLoader {
 	private static List<RawMesh> loadModel(Obj sourceObj, Map<String, Mtl> materials, Function<String, Identifier> textureResolver, AtlasManager atlasManager) {
 		final List<RawMesh> rawMeshes = new ArrayList<>();
 
-		ObjSplitting.splitByMaterialGroups(sourceObj).forEach((key, obj) -> {
+		final Map<String, Obj> materialGroups = ObjSplitting.splitByMaterialGroups(sourceObj);
+		if (materialGroups.isEmpty() && sourceObj.getNumFaces() > 0) {
+			materialGroups.put("", sourceObj);
+		}
+		materialGroups.forEach((key, obj) -> {
 			if (obj.getNumFaces() > 0) {
 				final Map<String, String> materialOptions = splitMaterialOptions(key);
 				final String materialGroupName = materialOptions.get("");

--- a/forge/1.20.4-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
+++ b/forge/1.20.4-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
@@ -108,7 +108,9 @@ public final class ObjModelLoader {
 					mesh.faces.add(new Face(new int[]{face.getVertexIndex(0), face.getVertexIndex(1), face.getVertexIndex(2)}));
 				}
 
-				atlasManager.applyToMesh(mesh);
+				if (atlasManager != null) {
+					atlasManager.applyToMesh(mesh);
+				}
 				mesh.validateVertexIndex();
 				rawMeshes.add(mesh);
 			}

--- a/forge/1.20.4-mapping/src/main/java/org/mtr/mapping/render/object/InstancedDrawHelper.java
+++ b/forge/1.20.4-mapping/src/main/java/org/mtr/mapping/render/object/InstancedDrawHelper.java
@@ -1,0 +1,71 @@
+package org.mtr.mapping.render.object;
+
+import org.lwjgl.opengl.ARBInstancedArrays;
+import org.lwjgl.opengl.GL;
+import org.lwjgl.opengl.GL33;
+import org.mtr.mapping.render.vertex.VertexAttributeMapping;
+import org.mtr.mapping.render.vertex.VertexAttributeType;
+
+import java.nio.ByteBuffer;
+
+public final class InstancedDrawHelper {
+
+	public static boolean setupInstanceAttributes(VertexArray vertexArray, VertexBuffer instanceBuffer, VertexAttributeMapping mapping, VertexAttributeType... vertexAttributeTypes) {
+		vertexArray.bind();
+		instanceBuffer.bind(GL33.GL_ARRAY_BUFFER);
+		boolean supported = true;
+		for (final VertexAttributeType vertexAttributeType : vertexAttributeTypes) {
+			supported &= setupInstanceAttribute(mapping, vertexAttributeType);
+		}
+		VertexArray.unbind();
+		return supported;
+	}
+
+	public static void setupInstanceAttributePointers(VertexBuffer instanceBuffer, VertexAttributeMapping mapping, int instanceOffsetBytes, VertexAttributeType... vertexAttributeTypes) {
+		instanceBuffer.bind(GL33.GL_ARRAY_BUFFER);
+		for (final VertexAttributeType vertexAttributeType : vertexAttributeTypes) {
+			vertexAttributeType.setupAttributePointer(mapping.strideInstance, instanceOffsetBytes + mapping.pointers.get(vertexAttributeType));
+		}
+	}
+
+	public static void uploadInstances(VertexBuffer instanceBuffer, ByteBuffer byteBuffer, int size) {
+		instanceBuffer.bind(GL33.GL_ARRAY_BUFFER);
+		instanceBuffer.upload(byteBuffer, size, VertexBuffer.USAGE_STREAM_DRAW);
+	}
+
+	public static void drawElementsInstanced(VertexArray vertexArray, int instanceCount) {
+		GL33.glDrawElementsInstanced(GL33.GL_TRIANGLES, vertexArray.indexBuffer.getVertexCount(), vertexArray.indexBuffer.indexType, 0, instanceCount);
+	}
+
+	private static boolean setupInstanceAttribute(VertexAttributeMapping mapping, VertexAttributeType vertexAttributeType) {
+		vertexAttributeType.toggleAttributeArray(true);
+		vertexAttributeType.setupAttributePointer(mapping.strideInstance, mapping.pointers.get(vertexAttributeType));
+		return applyInstanceAttributeDivisor(vertexAttributeType);
+	}
+
+	private static boolean applyInstanceAttributeDivisor(VertexAttributeType vertexAttributeType) {
+		boolean supported = true;
+		for (int i = 0; i < vertexAttributeType.span; i++) {
+			supported &= applyInstanceAttributeDivisor(vertexAttributeType.location + i);
+		}
+		return supported;
+	}
+
+	private static boolean applyInstanceAttributeDivisor(int location) {
+		try {
+			final org.lwjgl.opengl.GLCapabilities capabilities = GL.getCapabilities();
+			if (capabilities.OpenGL33) {
+				GL33.glVertexAttribDivisor(location, 1);
+				return true;
+			} else if (capabilities.GL_ARB_instanced_arrays) {
+				ARBInstancedArrays.glVertexAttribDivisorARB(location, 1);
+				return true;
+			}
+		} catch (IllegalStateException ignored) {
+		}
+		return false;
+	}
+
+	private InstancedDrawHelper() {
+	}
+}

--- a/forge/1.20.4-mapping/src/main/java/org/mtr/mapping/render/shader/PatchingResourceProvider.java
+++ b/forge/1.20.4-mapping/src/main/java/org/mtr/mapping/render/shader/PatchingResourceProvider.java
@@ -41,8 +41,10 @@ public final class PatchingResourceProvider implements ResourceProvider {
 					inputStream.close();
 					dataObject.addProperty("vertex", dataObject.get("vertex").getAsString() + "_modelmat");
 					final JsonArray attributeArray = dataObject.get("attributes").getAsJsonArray();
-					for (int i = 0; i < 6 - attributeArray.size(); i++) {
-						attributeArray.add("Dummy" + i);
+					int dummyIndex = 0;
+					while (attributeArray.size() < 6) {
+						attributeArray.add("Dummy" + dummyIndex);
+						dummyIndex++;
 					}
 					attributeArray.add("ModelMat");
 					returningContent = dataObject.toString();

--- a/forge/1.20.4-mapping/src/main/java/org/mtr/mapping/render/tool/GlStateTracker.java
+++ b/forge/1.20.4-mapping/src/main/java/org/mtr/mapping/render/tool/GlStateTracker.java
@@ -12,9 +12,24 @@ public final class GlStateTracker {
 	private static boolean supportVertexAttributeDivisor;
 	private static boolean isGl4ES = false;
 
+	private static final int SHADER_TEXTURE_COUNT = 8;
+
 	private static int vertArrayBinding;
 	private static int arrayBufBinding;
 	private static int elementBufBinding;
+	private static int activeTexture;
+	private static final int[] shaderTextures = new int[SHADER_TEXTURE_COUNT];
+	private static boolean blendEnabled;
+	private static boolean depthTestEnabled;
+	private static boolean cullEnabled;
+	private static boolean depthMask;
+	private static int depthFunc;
+	private static int blendSrcRgb;
+	private static int blendDstRgb;
+	private static int blendSrcAlpha;
+	private static int blendDstAlpha;
+	private static int blendEquationRgb;
+	private static int blendEquationAlpha;
 	private static ShaderInstance currentShaderProgram;
 	private static boolean isStateProtected;
 
@@ -31,6 +46,21 @@ public final class GlStateTracker {
 		vertArrayBinding = GL33.glGetInteger(GL33.GL_VERTEX_ARRAY_BINDING);
 		arrayBufBinding = GL33.glGetInteger(GL33.GL_ARRAY_BUFFER_BINDING);
 		elementBufBinding = GL33.glGetInteger(GL33.GL_ELEMENT_ARRAY_BUFFER_BINDING);
+		activeTexture = GL33.glGetInteger(GL33.GL_ACTIVE_TEXTURE);
+		for (int i = 0; i < SHADER_TEXTURE_COUNT; i++) {
+			shaderTextures[i] = RenderSystem.getShaderTexture(i);
+		}
+		blendEnabled = GL33.glIsEnabled(GL33.GL_BLEND);
+		depthTestEnabled = GL33.glIsEnabled(GL33.GL_DEPTH_TEST);
+		cullEnabled = GL33.glIsEnabled(GL33.GL_CULL_FACE);
+		depthMask = GL33.glGetBoolean(GL33.GL_DEPTH_WRITEMASK);
+		depthFunc = GL33.glGetInteger(GL33.GL_DEPTH_FUNC);
+		blendSrcRgb = GL33.glGetInteger(GL33.GL_BLEND_SRC_RGB);
+		blendDstRgb = GL33.glGetInteger(GL33.GL_BLEND_DST_RGB);
+		blendSrcAlpha = GL33.glGetInteger(GL33.GL_BLEND_SRC_ALPHA);
+		blendDstAlpha = GL33.glGetInteger(GL33.GL_BLEND_DST_ALPHA);
+		blendEquationRgb = GL33.glGetInteger(GL33.GL_BLEND_EQUATION_RGB);
+		blendEquationAlpha = GL33.glGetInteger(GL33.GL_BLEND_EQUATION_ALPHA);
 		currentShaderProgram = RenderSystem.getShader();
 		isStateProtected = true;
 	}
@@ -46,12 +76,44 @@ public final class GlStateTracker {
 		GL33.glBindBuffer(GL33.GL_ELEMENT_ARRAY_BUFFER, elementBufBinding);
 
 		RenderSystem.setShader(() -> currentShaderProgram);
+		for (int i = 0; i < SHADER_TEXTURE_COUNT; i++) {
+			RenderSystem.setShaderTexture(i, shaderTextures[i]);
+		}
+		GL33.glActiveTexture(activeTexture);
 
-		// Obtain original state from RenderSystem?
-		RenderSystem.enableCull();
-		RenderSystem.depthMask(true);
+		setBlend(blendEnabled);
+		setDepthTest(depthTestEnabled);
+		setCull(cullEnabled);
+		RenderSystem.depthMask(depthMask);
+		RenderSystem.depthFunc(depthFunc);
+		GL33.glBlendFuncSeparate(blendSrcRgb, blendDstRgb, blendSrcAlpha, blendDstAlpha);
+		GL33.glBlendEquationSeparate(blendEquationRgb, blendEquationAlpha);
 
 		isStateProtected = false;
+	}
+
+	private static void setBlend(boolean enabled) {
+		if (enabled) {
+			RenderSystem.enableBlend();
+		} else {
+			RenderSystem.disableBlend();
+		}
+	}
+
+	private static void setDepthTest(boolean enabled) {
+		if (enabled) {
+			RenderSystem.enableDepthTest();
+		} else {
+			RenderSystem.disableDepthTest();
+		}
+	}
+
+	private static void setCull(boolean enabled) {
+		if (enabled) {
+			RenderSystem.enableCull();
+		} else {
+			RenderSystem.disableCull();
+		}
 	}
 
 	public static void assertProtected() {


### PR DESCRIPTION
## Summary

This PR syncs the GPU OBJ mapping APIs across Fabric/Forge versions and expands the optimized rendering pipeline to support atlas-aware raw OBJ loading and generic instanced rendering helpers.

### What changed
- Unified `OptimizedModel`, `OptimizedRenderer`, `ObjModelLoader`, and related rendering helpers across multiple mappings/versions.
- Added atlas-aware raw OBJ loading support.
- Added reusable instanced rendering helpers and low-level buffer/VAO/vertex attribute utilities.
- Introduced GL state tracking and shader/material helpers to keep optimized rendering stable across versions.
- Fixed full-version OBJ handling and mapped-method checks.
- Added/updated tests for OBJ model behavior and mapping validation.

### Notes
- This is mainly a cross-version API/mapping sync plus rendering infrastructure update, not a single-feature change.
- The changes are aimed at reducing version-specific divergence and making the optimized GPU OBJ path more consistent.