### PR TITLE
Model loading-relate change and fix

### DIFF
--- a/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/fabric/1.16.5-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -2,11 +2,13 @@ package org.mtr.mapping.mapper;
 
 import org.mtr.mapping.annotation.MappedMethod;
 import org.mtr.mapping.holder.Identifier;
+import org.mtr.mapping.render.model.RawMesh;
 import org.mtr.mapping.tool.DummyClass;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -42,6 +44,11 @@ public final class OptimizedModel extends DummyClass {
 	}
 
 	public static final class ObjModel {
+		
+		@MappedMethod
+		public static Map<String, ObjModel> createObjModel(Map<String, List<RawMesh>> rawMeshesMap, boolean flipTextureV){
+			return new HashMap<>();
+		}
 
 		@MappedMethod
 		public static Map<String, ObjModel> loadModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, @Nullable Identifier atlasIndex, boolean splitModel, boolean flipTextureV) {

--- a/fabric/1.17.1-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/fabric/1.17.1-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -76,7 +76,7 @@ public final class OptimizedModel extends DummyClass {
 			uploadedParts.addAll(optimizedModel.uploadedParts);
 		}
 	}
-	
+
 	@MappedMethod
 	public void close() {
 		uploadedParts.forEach(VertexArray::close);
@@ -133,13 +133,9 @@ public final class OptimizedModel extends DummyClass {
 		}
 
 		@MappedMethod
-		public static Map<String, ObjModel> loadModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, @Nullable Identifier atlasIndex, boolean splitModel, boolean flipTextureV) {
-			if (atlasIndex != null) {
-				ATLAS_MANAGER.load(atlasIndex);
-			}
-
+		public static Map<String, ObjModel> createObjModel(Map<String, List<RawMesh>> rawMeshesMap, boolean flipTextureV) {
 			final Map<String, ObjModel> objModels = new HashMap<>();
-			ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel).forEach((key, rawMeshes) -> {
+			rawMeshesMap.forEach((key, rawMeshes) -> {
 				prepareRawMeshes(rawMeshes, flipTextureV);
 				final float[] bounds = {Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE};
 				rawMeshes.forEach(rawMesh -> {
@@ -159,6 +155,15 @@ public final class OptimizedModel extends DummyClass {
 			});
 
 			return objModels;
+		}
+
+		@MappedMethod
+		public static Map<String, ObjModel> loadModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, @Nullable Identifier atlasIndex, boolean splitModel, boolean flipTextureV) {
+			if (atlasIndex != null) {
+				ATLAS_MANAGER.load(atlasIndex);
+			}
+
+			return createObjModel(ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel), flipTextureV);
 		}
 
 		@MappedMethod
@@ -237,6 +242,7 @@ public final class OptimizedModel extends DummyClass {
 		public float getMaxZ() {
 			return maxZ;
 		}
+
 		private static void prepareRawMeshes(List<RawMesh> rawMeshes, boolean flipTextureV) {
 			rawMeshes.forEach(rawMesh -> {
 				rawMesh.applyRotation(new Vector3f(1, 0, 0), 180);

--- a/fabric/1.17.1-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
+++ b/fabric/1.17.1-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
@@ -13,6 +13,7 @@ import org.mtr.mapping.render.vertex.Vertex;
 import org.mtr.mapping.tool.DummyClass;
 
 import javax.annotation.Nullable;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.util.*;
@@ -24,12 +25,12 @@ public final class ObjModelLoader {
 		final Map<String, List<RawMesh>> result = new HashMap<>();
 
 		try {
-			final Obj sourceObj = ObjReader.read(IOUtils.toInputStream(objString, StandardCharsets.UTF_8));
+			final Obj sourceObj = ObjReader.read(new InputStreamReader(IOUtils.toInputStream(objString, StandardCharsets.UTF_8), StandardCharsets.UTF_8));
 
 			final Map<String, Mtl> materials = new HashMap<>();
 			sourceObj.getMtlFileNames().forEach(mtlFileName -> {
 				try {
-					MtlReader.read(IOUtils.toInputStream(mtlResolver.apply(mtlFileName.replace("\\\\", "/").replace("\\", "/")), StandardCharsets.UTF_8)).forEach(mtl -> materials.put(mtl.getName(), mtl));
+					MtlReader.read(new InputStreamReader(IOUtils.toInputStream(mtlResolver.apply(mtlFileName.replace("\\\\", "/").replace("\\", "/")), StandardCharsets.UTF_8), StandardCharsets.UTF_8)).forEach(mtl -> materials.put(mtl.getName(), mtl));
 				} catch (Exception e) {
 					DummyClass.logException(e);
 				}

--- a/fabric/1.18.2-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/fabric/1.18.2-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -133,13 +133,9 @@ public final class OptimizedModel extends DummyClass {
 		}
 
 		@MappedMethod
-		public static Map<String, ObjModel> loadModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, @Nullable Identifier atlasIndex, boolean splitModel, boolean flipTextureV) {
-			if (atlasIndex != null) {
-				ATLAS_MANAGER.load(atlasIndex);
-			}
-
+		public static Map<String, ObjModel> createObjModel(Map<String, List<RawMesh>> rawMeshesMap, boolean flipTextureV) {
 			final Map<String, ObjModel> objModels = new HashMap<>();
-			ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel).forEach((key, rawMeshes) -> {
+			rawMeshesMap.forEach((key, rawMeshes) -> {
 				prepareRawMeshes(rawMeshes, flipTextureV);
 				final float[] bounds = {Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE};
 				rawMeshes.forEach(rawMesh -> {
@@ -159,6 +155,15 @@ public final class OptimizedModel extends DummyClass {
 			});
 
 			return objModels;
+		}
+
+		@MappedMethod
+		public static Map<String, ObjModel> loadModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, @Nullable Identifier atlasIndex, boolean splitModel, boolean flipTextureV) {
+			if (atlasIndex != null) {
+				ATLAS_MANAGER.load(atlasIndex);
+			}
+
+			return createObjModel(ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel), flipTextureV);
 		}
 
 		@MappedMethod

--- a/fabric/1.18.2-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
+++ b/fabric/1.18.2-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
@@ -13,6 +13,7 @@ import org.mtr.mapping.render.vertex.Vertex;
 import org.mtr.mapping.tool.DummyClass;
 
 import javax.annotation.Nullable;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.util.*;
@@ -24,12 +25,12 @@ public final class ObjModelLoader {
 		final Map<String, List<RawMesh>> result = new HashMap<>();
 
 		try {
-			final Obj sourceObj = ObjReader.read(IOUtils.toInputStream(objString, StandardCharsets.UTF_8));
+			final Obj sourceObj = ObjReader.read(new InputStreamReader(IOUtils.toInputStream(objString, StandardCharsets.UTF_8), StandardCharsets.UTF_8));
 
 			final Map<String, Mtl> materials = new HashMap<>();
 			sourceObj.getMtlFileNames().forEach(mtlFileName -> {
 				try {
-					MtlReader.read(IOUtils.toInputStream(mtlResolver.apply(mtlFileName.replace("\\\\", "/").replace("\\", "/")), StandardCharsets.UTF_8)).forEach(mtl -> materials.put(mtl.getName(), mtl));
+					MtlReader.read(new InputStreamReader(IOUtils.toInputStream(mtlResolver.apply(mtlFileName.replace("\\\\", "/").replace("\\", "/")), StandardCharsets.UTF_8), StandardCharsets.UTF_8)).forEach(mtl -> materials.put(mtl.getName(), mtl));
 				} catch (Exception e) {
 					DummyClass.logException(e);
 				}

--- a/fabric/1.19.2-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/fabric/1.19.2-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -133,13 +133,9 @@ public final class OptimizedModel extends DummyClass {
 		}
 
 		@MappedMethod
-		public static Map<String, ObjModel> loadModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, @Nullable Identifier atlasIndex, boolean splitModel, boolean flipTextureV) {
-			if (atlasIndex != null) {
-				ATLAS_MANAGER.load(atlasIndex);
-			}
-
+		public static Map<String, ObjModel> createObjModel(Map<String, List<RawMesh>> rawMeshesMap, boolean flipTextureV) {
 			final Map<String, ObjModel> objModels = new HashMap<>();
-			ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel).forEach((key, rawMeshes) -> {
+			rawMeshesMap.forEach((key, rawMeshes) -> {
 				prepareRawMeshes(rawMeshes, flipTextureV);
 				final float[] bounds = {Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE};
 				rawMeshes.forEach(rawMesh -> {
@@ -159,6 +155,15 @@ public final class OptimizedModel extends DummyClass {
 			});
 
 			return objModels;
+		}
+
+		@MappedMethod
+		public static Map<String, ObjModel> loadModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, @Nullable Identifier atlasIndex, boolean splitModel, boolean flipTextureV) {
+			if (atlasIndex != null) {
+				ATLAS_MANAGER.load(atlasIndex);
+			}
+
+			return createObjModel(ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel), flipTextureV);
 		}
 
 		@MappedMethod

--- a/fabric/1.19.2-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
+++ b/fabric/1.19.2-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
@@ -13,6 +13,7 @@ import org.mtr.mapping.render.vertex.Vertex;
 import org.mtr.mapping.tool.DummyClass;
 
 import javax.annotation.Nullable;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.util.*;
@@ -24,12 +25,12 @@ public final class ObjModelLoader {
 		final Map<String, List<RawMesh>> result = new HashMap<>();
 
 		try {
-			final Obj sourceObj = ObjReader.read(IOUtils.toInputStream(objString, StandardCharsets.UTF_8));
+			final Obj sourceObj = ObjReader.read(new InputStreamReader(IOUtils.toInputStream(objString, StandardCharsets.UTF_8), StandardCharsets.UTF_8));
 
 			final Map<String, Mtl> materials = new HashMap<>();
 			sourceObj.getMtlFileNames().forEach(mtlFileName -> {
 				try {
-					MtlReader.read(IOUtils.toInputStream(mtlResolver.apply(mtlFileName.replace("\\\\", "/").replace("\\", "/")), StandardCharsets.UTF_8)).forEach(mtl -> materials.put(mtl.getName(), mtl));
+					MtlReader.read(new InputStreamReader(IOUtils.toInputStream(mtlResolver.apply(mtlFileName.replace("\\\\", "/").replace("\\", "/")), StandardCharsets.UTF_8), StandardCharsets.UTF_8)).forEach(mtl -> materials.put(mtl.getName(), mtl));
 				} catch (Exception e) {
 					DummyClass.logException(e);
 				}

--- a/fabric/1.19.4-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/fabric/1.19.4-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -133,13 +133,9 @@ public final class OptimizedModel extends DummyClass {
 		}
 
 		@MappedMethod
-		public static Map<String, ObjModel> loadModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, @Nullable Identifier atlasIndex, boolean splitModel, boolean flipTextureV) {
-			if (atlasIndex != null) {
-				ATLAS_MANAGER.load(atlasIndex);
-			}
-
+		public static Map<String, ObjModel> createObjModel(Map<String, List<RawMesh>> rawMeshesMap, boolean flipTextureV) {
 			final Map<String, ObjModel> objModels = new HashMap<>();
-			ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel).forEach((key, rawMeshes) -> {
+			rawMeshesMap.forEach((key, rawMeshes) -> {
 				prepareRawMeshes(rawMeshes, flipTextureV);
 				final float[] bounds = {Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE};
 				rawMeshes.forEach(rawMesh -> {
@@ -159,6 +155,15 @@ public final class OptimizedModel extends DummyClass {
 			});
 
 			return objModels;
+		}
+
+		@MappedMethod
+		public static Map<String, ObjModel> loadModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, @Nullable Identifier atlasIndex, boolean splitModel, boolean flipTextureV) {
+			if (atlasIndex != null) {
+				ATLAS_MANAGER.load(atlasIndex);
+			}
+
+			return createObjModel(ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel), flipTextureV);
 		}
 
 		@MappedMethod

--- a/fabric/1.19.4-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
+++ b/fabric/1.19.4-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
@@ -13,6 +13,7 @@ import org.mtr.mapping.render.vertex.Vertex;
 import org.mtr.mapping.tool.DummyClass;
 
 import javax.annotation.Nullable;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.util.*;
@@ -24,12 +25,12 @@ public final class ObjModelLoader {
 		final Map<String, List<RawMesh>> result = new HashMap<>();
 
 		try {
-			final Obj sourceObj = ObjReader.read(IOUtils.toInputStream(objString, StandardCharsets.UTF_8));
+			final Obj sourceObj = ObjReader.read(new InputStreamReader(IOUtils.toInputStream(objString, StandardCharsets.UTF_8), StandardCharsets.UTF_8));
 
 			final Map<String, Mtl> materials = new HashMap<>();
 			sourceObj.getMtlFileNames().forEach(mtlFileName -> {
 				try {
-					MtlReader.read(IOUtils.toInputStream(mtlResolver.apply(mtlFileName.replace("\\\\", "/").replace("\\", "/")), StandardCharsets.UTF_8)).forEach(mtl -> materials.put(mtl.getName(), mtl));
+					MtlReader.read(new InputStreamReader(IOUtils.toInputStream(mtlResolver.apply(mtlFileName.replace("\\\\", "/").replace("\\", "/")), StandardCharsets.UTF_8), StandardCharsets.UTF_8)).forEach(mtl -> materials.put(mtl.getName(), mtl));
 				} catch (Exception e) {
 					DummyClass.logException(e);
 				}

--- a/fabric/1.20.1-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/fabric/1.20.1-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -133,13 +133,9 @@ public final class OptimizedModel extends DummyClass {
 		}
 
 		@MappedMethod
-		public static Map<String, ObjModel> loadModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, @Nullable Identifier atlasIndex, boolean splitModel, boolean flipTextureV) {
-			if (atlasIndex != null) {
-				ATLAS_MANAGER.load(atlasIndex);
-			}
-
+		public static Map<String, ObjModel> createObjModel(Map<String, List<RawMesh>> rawMeshesMap, boolean flipTextureV) {
 			final Map<String, ObjModel> objModels = new HashMap<>();
-			ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel).forEach((key, rawMeshes) -> {
+			rawMeshesMap.forEach((key, rawMeshes) -> {
 				prepareRawMeshes(rawMeshes, flipTextureV);
 				final float[] bounds = {Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE};
 				rawMeshes.forEach(rawMesh -> {
@@ -159,6 +155,15 @@ public final class OptimizedModel extends DummyClass {
 			});
 
 			return objModels;
+		}
+
+		@MappedMethod
+		public static Map<String, ObjModel> loadModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, @Nullable Identifier atlasIndex, boolean splitModel, boolean flipTextureV) {
+			if (atlasIndex != null) {
+				ATLAS_MANAGER.load(atlasIndex);
+			}
+
+			return createObjModel(ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel), flipTextureV);
 		}
 
 		@MappedMethod

--- a/fabric/1.20.1-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
+++ b/fabric/1.20.1-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
@@ -13,6 +13,7 @@ import org.mtr.mapping.render.vertex.Vertex;
 import org.mtr.mapping.tool.DummyClass;
 
 import javax.annotation.Nullable;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.util.*;
@@ -24,12 +25,12 @@ public final class ObjModelLoader {
 		final Map<String, List<RawMesh>> result = new HashMap<>();
 
 		try {
-			final Obj sourceObj = ObjReader.read(IOUtils.toInputStream(objString, StandardCharsets.UTF_8));
+			final Obj sourceObj = ObjReader.read(new InputStreamReader(IOUtils.toInputStream(objString, StandardCharsets.UTF_8), StandardCharsets.UTF_8));
 
 			final Map<String, Mtl> materials = new HashMap<>();
 			sourceObj.getMtlFileNames().forEach(mtlFileName -> {
 				try {
-					MtlReader.read(IOUtils.toInputStream(mtlResolver.apply(mtlFileName.replace("\\\\", "/").replace("\\", "/")), StandardCharsets.UTF_8)).forEach(mtl -> materials.put(mtl.getName(), mtl));
+					MtlReader.read(new InputStreamReader(IOUtils.toInputStream(mtlResolver.apply(mtlFileName.replace("\\\\", "/").replace("\\", "/")), StandardCharsets.UTF_8), StandardCharsets.UTF_8)).forEach(mtl -> materials.put(mtl.getName(), mtl));
 				} catch (Exception e) {
 					DummyClass.logException(e);
 				}

--- a/fabric/1.20.4-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/fabric/1.20.4-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -133,13 +133,9 @@ public final class OptimizedModel extends DummyClass {
 		}
 
 		@MappedMethod
-		public static Map<String, ObjModel> loadModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, @Nullable Identifier atlasIndex, boolean splitModel, boolean flipTextureV) {
-			if (atlasIndex != null) {
-				ATLAS_MANAGER.load(atlasIndex);
-			}
-
+		public static Map<String, ObjModel> createObjModel(Map<String, List<RawMesh>> rawMeshesMap, boolean flipTextureV) {
 			final Map<String, ObjModel> objModels = new HashMap<>();
-			ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel).forEach((key, rawMeshes) -> {
+			rawMeshesMap.forEach((key, rawMeshes) -> {
 				prepareRawMeshes(rawMeshes, flipTextureV);
 				final float[] bounds = {Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE};
 				rawMeshes.forEach(rawMesh -> {
@@ -159,6 +155,15 @@ public final class OptimizedModel extends DummyClass {
 			});
 
 			return objModels;
+		}
+
+		@MappedMethod
+		public static Map<String, ObjModel> loadModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, @Nullable Identifier atlasIndex, boolean splitModel, boolean flipTextureV) {
+			if (atlasIndex != null) {
+				ATLAS_MANAGER.load(atlasIndex);
+			}
+
+			return createObjModel(ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel), flipTextureV);
 		}
 
 		@MappedMethod
@@ -237,7 +242,6 @@ public final class OptimizedModel extends DummyClass {
 		public float getMaxZ() {
 			return maxZ;
 		}
-
 		private static void prepareRawMeshes(List<RawMesh> rawMeshes, boolean flipTextureV) {
 			rawMeshes.forEach(rawMesh -> {
 				rawMesh.applyRotation(new Vector3f(1, 0, 0), 180);
@@ -246,6 +250,7 @@ public final class OptimizedModel extends DummyClass {
 				}
 			});
 		}
+
 	}
 
 	public enum ShaderType {

--- a/fabric/1.20.4-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
+++ b/fabric/1.20.4-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
@@ -13,6 +13,7 @@ import org.mtr.mapping.render.vertex.Vertex;
 import org.mtr.mapping.tool.DummyClass;
 
 import javax.annotation.Nullable;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.util.*;
@@ -24,12 +25,12 @@ public final class ObjModelLoader {
 		final Map<String, List<RawMesh>> result = new HashMap<>();
 
 		try {
-			final Obj sourceObj = ObjReader.read(IOUtils.toInputStream(objString, StandardCharsets.UTF_8));
+			final Obj sourceObj = ObjReader.read(new InputStreamReader(IOUtils.toInputStream(objString, StandardCharsets.UTF_8), StandardCharsets.UTF_8));
 
 			final Map<String, Mtl> materials = new HashMap<>();
 			sourceObj.getMtlFileNames().forEach(mtlFileName -> {
 				try {
-					MtlReader.read(IOUtils.toInputStream(mtlResolver.apply(mtlFileName.replace("\\\\", "/").replace("\\", "/")), StandardCharsets.UTF_8)).forEach(mtl -> materials.put(mtl.getName(), mtl));
+					MtlReader.read(new InputStreamReader(IOUtils.toInputStream(mtlResolver.apply(mtlFileName.replace("\\\\", "/").replace("\\", "/")), StandardCharsets.UTF_8), StandardCharsets.UTF_8)).forEach(mtl -> materials.put(mtl.getName(), mtl));
 				} catch (Exception e) {
 					DummyClass.logException(e);
 				}

--- a/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/forge/1.16.5-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -2,11 +2,13 @@ package org.mtr.mapping.mapper;
 
 import org.mtr.mapping.annotation.MappedMethod;
 import org.mtr.mapping.holder.Identifier;
+import org.mtr.mapping.render.model.RawMesh;
 import org.mtr.mapping.tool.DummyClass;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -42,9 +44,14 @@ public final class OptimizedModel extends DummyClass {
 	}
 
 	public static final class ObjModel {
+		
+		@MappedMethod
+		public static Map<String, ObjModel> createObjModel(Map<String, List<RawMesh>> rawMeshesMap, boolean flipTextureV){
+			return new HashMap<>();
+		}
 
 		@MappedMethod
-		public static Map<String, ObjModel> loadModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier>textureResolver, @Nullable Identifier atlasIndex, boolean splitModel, boolean flipTextureV) {
+		public static Map<String, ObjModel> loadModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, @Nullable Identifier atlasIndex, boolean splitModel, boolean flipTextureV) {
 			return new HashMap<>();
 		}
 

--- a/forge/1.17.1-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/forge/1.17.1-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -132,13 +132,9 @@ public final class OptimizedModel extends DummyClass {
 		}
 
 		@MappedMethod
-		public static Map<String, ObjModel> loadModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, @Nullable Identifier atlasIndex, boolean splitModel, boolean flipTextureV) {
-			if (atlasIndex != null) {
-				ATLAS_MANAGER.load(atlasIndex);
-			}
-
+		public static Map<String, ObjModel> createObjModel(Map<String, List<RawMesh>> rawMeshesMap, boolean flipTextureV) {
 			final Map<String, ObjModel> objModels = new HashMap<>();
-			ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel).forEach((key, rawMeshes) -> {
+			rawMeshesMap.forEach((key, rawMeshes) -> {
 				prepareRawMeshes(rawMeshes, flipTextureV);
 				final float[] bounds = {Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE};
 				rawMeshes.forEach(rawMesh -> {
@@ -158,6 +154,15 @@ public final class OptimizedModel extends DummyClass {
 			});
 
 			return objModels;
+		}
+
+		@MappedMethod
+		public static Map<String, ObjModel> loadModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, @Nullable Identifier atlasIndex, boolean splitModel, boolean flipTextureV) {
+			if (atlasIndex != null) {
+				ATLAS_MANAGER.load(atlasIndex);
+			}
+
+			return createObjModel(ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel), flipTextureV);
 		}
 
 		@MappedMethod

--- a/forge/1.17.1-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
+++ b/forge/1.17.1-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
@@ -13,6 +13,7 @@ import org.mtr.mapping.render.vertex.Vertex;
 import org.mtr.mapping.tool.DummyClass;
 
 import javax.annotation.Nullable;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.util.*;
@@ -24,12 +25,12 @@ public final class ObjModelLoader {
 		final Map<String, List<RawMesh>> result = new HashMap<>();
 
 		try {
-			final Obj sourceObj = ObjReader.read(IOUtils.toInputStream(objString, StandardCharsets.UTF_8));
+			final Obj sourceObj = ObjReader.read(new InputStreamReader(IOUtils.toInputStream(objString, StandardCharsets.UTF_8), StandardCharsets.UTF_8));
 
 			final Map<String, Mtl> materials = new HashMap<>();
 			sourceObj.getMtlFileNames().forEach(mtlFileName -> {
 				try {
-					MtlReader.read(IOUtils.toInputStream(mtlResolver.apply(mtlFileName.replace("\\\\", "/").replace("\\", "/")), StandardCharsets.UTF_8)).forEach(mtl -> materials.put(mtl.getName(), mtl));
+					MtlReader.read(new InputStreamReader(IOUtils.toInputStream(mtlResolver.apply(mtlFileName.replace("\\\\", "/").replace("\\", "/")), StandardCharsets.UTF_8), StandardCharsets.UTF_8)).forEach(mtl -> materials.put(mtl.getName(), mtl));
 				} catch (Exception e) {
 					DummyClass.logException(e);
 				}

--- a/forge/1.18.2-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/forge/1.18.2-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -132,13 +132,9 @@ public final class OptimizedModel extends DummyClass {
 		}
 
 		@MappedMethod
-		public static Map<String, ObjModel> loadModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, @Nullable Identifier atlasIndex, boolean splitModel, boolean flipTextureV) {
-			if (atlasIndex != null) {
-				ATLAS_MANAGER.load(atlasIndex);
-			}
-
+		public static Map<String, ObjModel> createObjModel(Map<String, List<RawMesh>> rawMeshesMap, boolean flipTextureV) {
 			final Map<String, ObjModel> objModels = new HashMap<>();
-			ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel).forEach((key, rawMeshes) -> {
+			rawMeshesMap.forEach((key, rawMeshes) -> {
 				prepareRawMeshes(rawMeshes, flipTextureV);
 				final float[] bounds = {Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE};
 				rawMeshes.forEach(rawMesh -> {
@@ -158,6 +154,15 @@ public final class OptimizedModel extends DummyClass {
 			});
 
 			return objModels;
+		}
+
+		@MappedMethod
+		public static Map<String, ObjModel> loadModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, @Nullable Identifier atlasIndex, boolean splitModel, boolean flipTextureV) {
+			if (atlasIndex != null) {
+				ATLAS_MANAGER.load(atlasIndex);
+			}
+
+			return createObjModel(ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel), flipTextureV);
 		}
 
 		@MappedMethod

--- a/forge/1.18.2-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
+++ b/forge/1.18.2-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
@@ -13,6 +13,7 @@ import org.mtr.mapping.render.vertex.Vertex;
 import org.mtr.mapping.tool.DummyClass;
 
 import javax.annotation.Nullable;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.util.*;
@@ -24,12 +25,12 @@ public final class ObjModelLoader {
 		final Map<String, List<RawMesh>> result = new HashMap<>();
 
 		try {
-			final Obj sourceObj = ObjReader.read(IOUtils.toInputStream(objString, StandardCharsets.UTF_8));
+			final Obj sourceObj = ObjReader.read(new InputStreamReader(IOUtils.toInputStream(objString, StandardCharsets.UTF_8), StandardCharsets.UTF_8));
 
 			final Map<String, Mtl> materials = new HashMap<>();
 			sourceObj.getMtlFileNames().forEach(mtlFileName -> {
 				try {
-					MtlReader.read(IOUtils.toInputStream(mtlResolver.apply(mtlFileName.replace("\\\\", "/").replace("\\", "/")), StandardCharsets.UTF_8)).forEach(mtl -> materials.put(mtl.getName(), mtl));
+					MtlReader.read(new InputStreamReader(IOUtils.toInputStream(mtlResolver.apply(mtlFileName.replace("\\\\", "/").replace("\\", "/")), StandardCharsets.UTF_8), StandardCharsets.UTF_8)).forEach(mtl -> materials.put(mtl.getName(), mtl));
 				} catch (Exception e) {
 					DummyClass.logException(e);
 				}

--- a/forge/1.19.2-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/forge/1.19.2-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -132,13 +132,9 @@ public final class OptimizedModel extends DummyClass {
 		}
 
 		@MappedMethod
-		public static Map<String, ObjModel> loadModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, @Nullable Identifier atlasIndex, boolean splitModel, boolean flipTextureV) {
-			if (atlasIndex != null) {
-				ATLAS_MANAGER.load(atlasIndex);
-			}
-
+		public static Map<String, ObjModel> createObjModel(Map<String, List<RawMesh>> rawMeshesMap, boolean flipTextureV) {
 			final Map<String, ObjModel> objModels = new HashMap<>();
-			ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel).forEach((key, rawMeshes) -> {
+			rawMeshesMap.forEach((key, rawMeshes) -> {
 				prepareRawMeshes(rawMeshes, flipTextureV);
 				final float[] bounds = {Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE};
 				rawMeshes.forEach(rawMesh -> {
@@ -158,6 +154,15 @@ public final class OptimizedModel extends DummyClass {
 			});
 
 			return objModels;
+		}
+
+		@MappedMethod
+		public static Map<String, ObjModel> loadModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, @Nullable Identifier atlasIndex, boolean splitModel, boolean flipTextureV) {
+			if (atlasIndex != null) {
+				ATLAS_MANAGER.load(atlasIndex);
+			}
+
+			return createObjModel(ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel), flipTextureV);
 		}
 
 		@MappedMethod

--- a/forge/1.19.2-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
+++ b/forge/1.19.2-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
@@ -13,6 +13,7 @@ import org.mtr.mapping.render.vertex.Vertex;
 import org.mtr.mapping.tool.DummyClass;
 
 import javax.annotation.Nullable;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.util.*;
@@ -24,12 +25,12 @@ public final class ObjModelLoader {
 		final Map<String, List<RawMesh>> result = new HashMap<>();
 
 		try {
-			final Obj sourceObj = ObjReader.read(IOUtils.toInputStream(objString, StandardCharsets.UTF_8));
+			final Obj sourceObj = ObjReader.read(new InputStreamReader(IOUtils.toInputStream(objString, StandardCharsets.UTF_8), StandardCharsets.UTF_8));
 
 			final Map<String, Mtl> materials = new HashMap<>();
 			sourceObj.getMtlFileNames().forEach(mtlFileName -> {
 				try {
-					MtlReader.read(IOUtils.toInputStream(mtlResolver.apply(mtlFileName.replace("\\\\", "/").replace("\\", "/")), StandardCharsets.UTF_8)).forEach(mtl -> materials.put(mtl.getName(), mtl));
+					MtlReader.read(new InputStreamReader(IOUtils.toInputStream(mtlResolver.apply(mtlFileName.replace("\\\\", "/").replace("\\", "/")), StandardCharsets.UTF_8), StandardCharsets.UTF_8)).forEach(mtl -> materials.put(mtl.getName(), mtl));
 				} catch (Exception e) {
 					DummyClass.logException(e);
 				}

--- a/forge/1.19.4-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/forge/1.19.4-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -133,13 +133,9 @@ public final class OptimizedModel extends DummyClass {
 		}
 
 		@MappedMethod
-		public static Map<String, ObjModel> loadModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, @Nullable Identifier atlasIndex, boolean splitModel, boolean flipTextureV) {
-			if (atlasIndex != null) {
-				ATLAS_MANAGER.load(atlasIndex);
-			}
-
+		public static Map<String, ObjModel> createObjModel(Map<String, List<RawMesh>> rawMeshesMap, boolean flipTextureV) {
 			final Map<String, ObjModel> objModels = new HashMap<>();
-			ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel).forEach((key, rawMeshes) -> {
+			rawMeshesMap.forEach((key, rawMeshes) -> {
 				prepareRawMeshes(rawMeshes, flipTextureV);
 				final float[] bounds = {Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE};
 				rawMeshes.forEach(rawMesh -> {
@@ -159,6 +155,15 @@ public final class OptimizedModel extends DummyClass {
 			});
 
 			return objModels;
+		}
+
+		@MappedMethod
+		public static Map<String, ObjModel> loadModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, @Nullable Identifier atlasIndex, boolean splitModel, boolean flipTextureV) {
+			if (atlasIndex != null) {
+				ATLAS_MANAGER.load(atlasIndex);
+			}
+
+			return createObjModel(ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel), flipTextureV);
 		}
 
 		@MappedMethod

--- a/forge/1.19.4-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
+++ b/forge/1.19.4-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
@@ -13,6 +13,7 @@ import org.mtr.mapping.render.vertex.Vertex;
 import org.mtr.mapping.tool.DummyClass;
 
 import javax.annotation.Nullable;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.util.*;
@@ -24,12 +25,12 @@ public final class ObjModelLoader {
 		final Map<String, List<RawMesh>> result = new HashMap<>();
 
 		try {
-			final Obj sourceObj = ObjReader.read(IOUtils.toInputStream(objString, StandardCharsets.UTF_8));
+			final Obj sourceObj = ObjReader.read(new InputStreamReader(IOUtils.toInputStream(objString, StandardCharsets.UTF_8), StandardCharsets.UTF_8));
 
 			final Map<String, Mtl> materials = new HashMap<>();
 			sourceObj.getMtlFileNames().forEach(mtlFileName -> {
 				try {
-					MtlReader.read(IOUtils.toInputStream(mtlResolver.apply(mtlFileName.replace("\\\\", "/").replace("\\", "/")), StandardCharsets.UTF_8)).forEach(mtl -> materials.put(mtl.getName(), mtl));
+					MtlReader.read(new InputStreamReader(IOUtils.toInputStream(mtlResolver.apply(mtlFileName.replace("\\\\", "/").replace("\\", "/")), StandardCharsets.UTF_8), StandardCharsets.UTF_8)).forEach(mtl -> materials.put(mtl.getName(), mtl));
 				} catch (Exception e) {
 					DummyClass.logException(e);
 				}

--- a/forge/1.20.1-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/forge/1.20.1-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -133,13 +133,9 @@ public final class OptimizedModel extends DummyClass {
 		}
 
 		@MappedMethod
-		public static Map<String, ObjModel> loadModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, @Nullable Identifier atlasIndex, boolean splitModel, boolean flipTextureV) {
-			if (atlasIndex != null) {
-				ATLAS_MANAGER.load(atlasIndex);
-			}
-
+		public static Map<String, ObjModel> createObjModel(Map<String, List<RawMesh>> rawMeshesMap, boolean flipTextureV) {
 			final Map<String, ObjModel> objModels = new HashMap<>();
-			ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel).forEach((key, rawMeshes) -> {
+			rawMeshesMap.forEach((key, rawMeshes) -> {
 				prepareRawMeshes(rawMeshes, flipTextureV);
 				final float[] bounds = {Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE};
 				rawMeshes.forEach(rawMesh -> {
@@ -159,6 +155,15 @@ public final class OptimizedModel extends DummyClass {
 			});
 
 			return objModels;
+		}
+
+		@MappedMethod
+		public static Map<String, ObjModel> loadModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, @Nullable Identifier atlasIndex, boolean splitModel, boolean flipTextureV) {
+			if (atlasIndex != null) {
+				ATLAS_MANAGER.load(atlasIndex);
+			}
+
+			return createObjModel(ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel), flipTextureV);
 		}
 
 		@MappedMethod

--- a/forge/1.20.1-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
+++ b/forge/1.20.1-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
@@ -13,6 +13,7 @@ import org.mtr.mapping.render.vertex.Vertex;
 import org.mtr.mapping.tool.DummyClass;
 
 import javax.annotation.Nullable;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.util.*;
@@ -24,12 +25,12 @@ public final class ObjModelLoader {
 		final Map<String, List<RawMesh>> result = new HashMap<>();
 
 		try {
-			final Obj sourceObj = ObjReader.read(IOUtils.toInputStream(objString, StandardCharsets.UTF_8));
+			final Obj sourceObj = ObjReader.read(new InputStreamReader(IOUtils.toInputStream(objString, StandardCharsets.UTF_8), StandardCharsets.UTF_8));
 
 			final Map<String, Mtl> materials = new HashMap<>();
 			sourceObj.getMtlFileNames().forEach(mtlFileName -> {
 				try {
-					MtlReader.read(IOUtils.toInputStream(mtlResolver.apply(mtlFileName.replace("\\\\", "/").replace("\\", "/")), StandardCharsets.UTF_8)).forEach(mtl -> materials.put(mtl.getName(), mtl));
+					MtlReader.read(new InputStreamReader(IOUtils.toInputStream(mtlResolver.apply(mtlFileName.replace("\\\\", "/").replace("\\", "/")), StandardCharsets.UTF_8), StandardCharsets.UTF_8)).forEach(mtl -> materials.put(mtl.getName(), mtl));
 				} catch (Exception e) {
 					DummyClass.logException(e);
 				}

--- a/forge/1.20.4-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
+++ b/forge/1.20.4-mapping/src/main/java/org/mtr/mapping/mapper/OptimizedModel.java
@@ -133,13 +133,9 @@ public final class OptimizedModel extends DummyClass {
 		}
 
 		@MappedMethod
-		public static Map<String, ObjModel> loadModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, @Nullable Identifier atlasIndex, boolean splitModel, boolean flipTextureV) {
-			if (atlasIndex != null) {
-				ATLAS_MANAGER.load(atlasIndex);
-			}
-
+		public static Map<String, ObjModel> createObjModel(Map<String, List<RawMesh>> rawMeshesMap, boolean flipTextureV) {
 			final Map<String, ObjModel> objModels = new HashMap<>();
-			ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel).forEach((key, rawMeshes) -> {
+			rawMeshesMap.forEach((key, rawMeshes) -> {
 				prepareRawMeshes(rawMeshes, flipTextureV);
 				final float[] bounds = {Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE};
 				rawMeshes.forEach(rawMesh -> {
@@ -159,6 +155,15 @@ public final class OptimizedModel extends DummyClass {
 			});
 
 			return objModels;
+		}
+
+		@MappedMethod
+		public static Map<String, ObjModel> loadModel(String objString, Function<String, String> mtlResolver, Function<String, Identifier> textureResolver, @Nullable Identifier atlasIndex, boolean splitModel, boolean flipTextureV) {
+			if (atlasIndex != null) {
+				ATLAS_MANAGER.load(atlasIndex);
+			}
+
+			return createObjModel(ObjModelLoader.loadModel(objString, mtlResolver, textureResolver, ATLAS_MANAGER, splitModel), flipTextureV);
 		}
 
 		@MappedMethod

--- a/forge/1.20.4-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
+++ b/forge/1.20.4-mapping/src/main/java/org/mtr/mapping/render/obj/ObjModelLoader.java
@@ -13,6 +13,7 @@ import org.mtr.mapping.render.vertex.Vertex;
 import org.mtr.mapping.tool.DummyClass;
 
 import javax.annotation.Nullable;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.util.*;
@@ -24,12 +25,12 @@ public final class ObjModelLoader {
 		final Map<String, List<RawMesh>> result = new HashMap<>();
 
 		try {
-			final Obj sourceObj = ObjReader.read(IOUtils.toInputStream(objString, StandardCharsets.UTF_8));
+			final Obj sourceObj = ObjReader.read(new InputStreamReader(IOUtils.toInputStream(objString, StandardCharsets.UTF_8), StandardCharsets.UTF_8));
 
 			final Map<String, Mtl> materials = new HashMap<>();
 			sourceObj.getMtlFileNames().forEach(mtlFileName -> {
 				try {
-					MtlReader.read(IOUtils.toInputStream(mtlResolver.apply(mtlFileName.replace("\\\\", "/").replace("\\", "/")), StandardCharsets.UTF_8)).forEach(mtl -> materials.put(mtl.getName(), mtl));
+					MtlReader.read(new InputStreamReader(IOUtils.toInputStream(mtlResolver.apply(mtlFileName.replace("\\\\", "/").replace("\\", "/")), StandardCharsets.UTF_8), StandardCharsets.UTF_8)).forEach(mtl -> materials.put(mtl.getName(), mtl));
 				} catch (Exception e) {
 					DummyClass.logException(e);
 				}


### PR DESCRIPTION
- Add `ObjModel.createObjModel(Map<String, List<RawMesh>> rawMeshesMap, boolean flipTextureV)` to allow create obj models from `RawMesh`
- Fix issues about model loading. Load mtl and obj files use UTF-8 encoding.